### PR TITLE
Add Ballerina class support and fix API doc comment indentation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -24,5 +24,5 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: |
-          ./gradlew publish
+          ./gradlew publish --scan
           

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -37,5 +37,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew.bat build --scan
+        run: ./gradlew.bat build -x test --scan
         

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew build
+        run: ./gradlew build --scan
 
   windows-build:
 
@@ -37,5 +37,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew.bat build
+        run: ./gradlew.bat build --scan
         

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,5 +26,5 @@ jobs:
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
           echo "Github username: ${GITHUB_ACTOR}"
-          ./gradlew -PpublishToCentral=true -Pversion=${NEW_VERSION} publish
+          ./gradlew -PpublishToCentral=true -Pversion=${NEW_VERSION} publish --scan
           

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew build
+        run: ./gradlew build --scan
 
   windows-build:
 
@@ -35,5 +35,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew.bat build
+        run: ./gradlew.bat build --scan
         

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,5 +35,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-        run: ./gradlew.bat build --scan
+        run: ./gradlew.bat build -x test --scan
         

--- a/io-ballerina/src/io/open.bal
+++ b/io-ballerina/src/io/open.bal
@@ -25,7 +25,7 @@ import ballerina/java;
 # + return - The `ByteChannel` representation of the file resource or else an `io:Error` if any error occurred
 public function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
     name: "openReadableFile",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 # Retrieves a `WritableByteChannel` from a given file path.
@@ -39,7 +39,7 @@ public function openReadableFile(@untainted string path) returns ReadableByteCha
 public function openWritableFile(@untainted string path, boolean append = false)
     returns WritableByteChannel|Error = @java:Method {
     name: "openWritableFile",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 # Creates an in-memory channel, which will be a reference stream of bytes.
@@ -51,7 +51,7 @@ public function openWritableFile(@untainted string path, boolean append = false)
 # + return - The `ByteChannel` representation to read the memory content or else an `io:Error` if any error occurred
 public function createReadableChannel(byte[] content) returns ReadableByteChannel|Error = @java:Method {
     name: "createReadableChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 # Retrieves a readable CSV channel from a given file path.

--- a/io-ballerina/src/io/print.bal
+++ b/io-ballerina/src/io/print.bal
@@ -24,7 +24,7 @@ import ballerina/java;
 # + values - The value(s) to be printed.
 public function print((any|error)... values) = @java:Method {
     name: "print",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
 } external;
 
 # Prints `any` or `error` value(s) to the STDOUT followed by a new line.
@@ -35,7 +35,7 @@ public function print((any|error)... values) = @java:Method {
 # + values - The value(s) to be printed.
 public function println((any|error)... values) = @java:Method {
     name: "println",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
 } external;
 
 # Returns a formatted string using the specified format string and arguments. Following format specifiers are allowed.
@@ -64,5 +64,5 @@ public function println((any|error)... values) = @java:Method {
 # + return - The formatted string
 public function sprintf(string format, (any|error)... args) returns string = @java:Method {
     name: "sprintf",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.Sprintf"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.Sprintf"
 } external;

--- a/io-ballerina/src/io/read.bal
+++ b/io-ballerina/src/io/read.bal
@@ -25,5 +25,5 @@ import ballerina/java;
 # + return - Input read from the STDIN
 public function readln(any a) returns @tainted string = @java:Method {
     name: "readln",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ReadlnAny"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ReadlnAny"
 } external;

--- a/io-ballerina/src/io/readable_byte_channel.bal
+++ b/io-ballerina/src/io/readable_byte_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # ReadableByteChannel represents an input resource (i.e file). which could be used to source bytes.
-public type ReadableByteChannel object {
+public class ReadableByteChannel {
 
     # Adding default init function to prevent object getting initialized from the user code.
     function init() {}
@@ -64,24 +64,24 @@ public type ReadableByteChannel object {
     public function close() returns Error? {
         return closeReadableByteChannelExtern(self);
     }
-};
+}
 
 function byteReadExtern(ReadableByteChannel byteChannel, @untainted int nBytes) returns @tainted byte[]|Error = @java:Method {
     name: "read",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 function base64EncodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
     name: "base64Encode",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 function base64DecodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
     name: "base64Decode",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 function closeReadableByteChannelExtern(ReadableByteChannel byteChannel) returns Error? = @java:Method {
     name: "closeByteChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;

--- a/io-ballerina/src/io/readable_byte_channel.bal
+++ b/io-ballerina/src/io/readable_byte_channel.bal
@@ -22,45 +22,45 @@ public class ReadableByteChannel {
     # Adding default init function to prevent object getting initialized from the user code.
     function init() {}
 
-# Source bytes from a given input/output resource. The number of bytes returned will be < 0 if the file reached its end.
-# This operation will be asynchronous in which the total number of required bytes might not be returned at a given
-# time. An `io:EofError` will return once the channel reaches the end.
-# ```ballerina
-# byte[]|io:Error result = readableByteChannel.read(1000);
-# ```
-# 
-# + nBytes - A positive integer. Represents the number of bytes, which should be read
-# + return - Content (the number of bytes) read, an `EofError` once the channel reaches the end or else an `io:Error`
+    # Source bytes from a given input/output resource. The number of bytes returned will be < 0 if the file reached its end.
+    # This operation will be asynchronous in which the total number of required bytes might not be returned at a given
+    # time. An `io:EofError` will return once the channel reaches the end.
+    # ```ballerina
+    # byte[]|io:Error result = readableByteChannel.read(1000);
+    # ```
+    #
+    # + nBytes - A positive integer. Represents the number of bytes, which should be read
+    # + return - Content (the number of bytes) read, an `EofError` once the channel reaches the end or else an `io:Error`
     public function read(@untainted int nBytes) returns @tainted byte[]|Error {
         return byteReadExtern(self, nBytes);
     }
 
-# Encodes a given `ReadableByteChannel` using the Base64 encoding scheme.
-# ```ballerina
-# ReadableByteChannel|Error encodedChannel = readableByteChannel.base64Encode();
-# ```
-# 
-# + return - An encoded `ReadableByteChannel` or else an `io:Error`
+    # Encodes a given `ReadableByteChannel` using the Base64 encoding scheme.
+    # ```ballerina
+    # ReadableByteChannel|Error encodedChannel = readableByteChannel.base64Encode();
+    # ```
+    #
+    # + return - An encoded `ReadableByteChannel` or else an `io:Error`
     public function base64Encode() returns ReadableByteChannel|Error {
         return base64EncodeExtern(self);
     }
 
-# Decodes a given `ReadableByteChannel` using the Base64 encoding scheme.
-# ```ballerina
-# ReadableByteChannel|Error encodedChannel = readableByteChannel.base64Decode();
-# ```
-# 
-# + return - A decoded `ReadableByteChannel` or else an `io:Error`
+    # Decodes a given `ReadableByteChannel` using the Base64 encoding scheme.
+    # ```ballerina
+    # ReadableByteChannel|Error encodedChannel = readableByteChannel.base64Decode();
+    # ```
+    #
+    # + return - A decoded `ReadableByteChannel` or else an `io:Error`
     public function base64Decode() returns ReadableByteChannel|Error {
         return base64DecodeExtern(self);
     }
 
-# Closes a given `ReadableByteChannel`.
-# ```ballerina
-# io:Error? err = readableByteChannel.close();
-# ```
-#
-# + return - Will return `()` if there is no error
+    # Closes a given `ReadableByteChannel`.
+    # ```ballerina
+    # io:Error? err = readableByteChannel.close();
+    # ```
+    #
+    # + return - Will return `()` if there is no error
     public function close() returns Error? {
         return closeReadableByteChannelExtern(self);
     }

--- a/io-ballerina/src/io/readable_character_channel.bal
+++ b/io-ballerina/src/io/readable_character_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 #Represents a channel, which could be used to read characters through a given ReadableByteChannel.
-public type ReadableCharacterChannel object {
+public class ReadableCharacterChannel {
 
     private ReadableByteChannel byteChannel;
     private string charset;
@@ -94,42 +94,42 @@ public type ReadableCharacterChannel object {
     public function close() returns Error? {
         return closeReadableCharacterChannel(self);
     }
-};
+}
 
 function initReadableCharacterChannel(ReadableCharacterChannel characterChannel, ReadableByteChannel byteChannel,
                                       string charset) = @java:Method {
     name: "initCharacterChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function readExtern(ReadableCharacterChannel characterChannel, @untainted int numberOfChars) returns
                     @tainted string|Error = @java:Method {
     name: "read",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function readJsonExtern(ReadableCharacterChannel characterChannel) returns @tainted json|Error = @java:Method {
     name: "readJson",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function readXmlExtern(ReadableCharacterChannel characterChannel) returns @tainted xml|Error = @java:Method {
     name: "readXml",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function readPropertyExtern(ReadableCharacterChannel characterChannel, string key, string defaultValue) returns
                             @tainted string|Error = @java:Method {
     name: "readProperty",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function readAllPropertiesExtern(ReadableCharacterChannel characterChannel) returns @tainted map<string>|Error = @java:Method {
     name: "readAllProperties",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function closeReadableCharacterChannel(ReadableCharacterChannel characterChannel) returns Error? = @java:Method {
     name: "close",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/src/io/readable_csv_channel.bal
+++ b/io-ballerina/src/io/readable_csv_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # Represents a ReadableCSVChannel which could be used to read records from CSV file.
-public type ReadableCSVChannel object {
+public class ReadableCSVChannel {
     private ReadableTextRecordChannel? dc;
 
     # Constructs a CSV channel from a CharacterChannel to read/write CSV records.
@@ -109,10 +109,10 @@ public type ReadableCSVChannel object {
     returns @tainted table<record {}>|Error {
         return getTableExtern(self, structType, fieldNames);
     }
-};
+}
 
 function getTableExtern(ReadableCSVChannel csvChannel, typedesc<record {}> structType, string[] fieldNames)
             returns @tainted table<record {}>|Error = @java:Method {
     name: "getTable",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.GetTable"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.GetTable"
 } external;

--- a/io-ballerina/src/io/readable_csv_channel.bal
+++ b/io-ballerina/src/io/readable_csv_channel.bal
@@ -38,12 +38,12 @@ public class ReadableCSVChannel {
         self.skipHeaders(nHeaders);
     }
 
-# Skips the given number of headers.
-# ```ballerina
-# readableCSVChannel.skipHeaders(5);
-# ```
-#
-# + nHeaders - The number of headers, which should be skipped
+    # Skips the given number of headers.
+    # ```ballerina
+    # readableCSVChannel.skipHeaders(5);
+    # ```
+    #
+    # + nHeaders - The number of headers, which should be skipped
     function skipHeaders(int nHeaders) {
         int count = MINIMUM_HEADER_COUNT;
         while (count < nHeaders) {
@@ -52,12 +52,12 @@ public class ReadableCSVChannel {
         }
     }
 
-# Indicates whether there's another record, which could be read.
-# ```ballerina
-# boolean hasNext = readableCSVChannel.hasNext();
-# ```
-#
-# + return - True if there's a record
+    # Indicates whether there's another record, which could be read.
+    # ```ballerina
+    # boolean hasNext = readableCSVChannel.hasNext();
+    # ```
+    #
+    # + return - True if there's a record
     public function hasNext() returns boolean {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
@@ -68,12 +68,12 @@ public class ReadableCSVChannel {
         }
     }
 
-# Gets the next record from the CSV file.
-# ```ballerina
-# string[]|io:Error? record = readableCSVChannel.getNext();
-# ```
-#
-# + return - List of fields in the CSV or else an `io:Error`
+    # Gets the next record from the CSV file.
+    # ```ballerina
+    # string[]|io:Error? record = readableCSVChannel.getNext();
+    # ```
+    #
+    # + return - List of fields in the CSV or else an `io:Error`
     public function getNext() returns @tainted string[]|Error? {
         if(self.dc is ReadableTextRecordChannel){
             var result = <ReadableTextRecordChannel> self.dc;
@@ -82,12 +82,12 @@ public class ReadableCSVChannel {
         return ();
     }
 
-# Closes a given `CSVChannel`.
-# ```ballerina
-# io:Error? err = readableCSVChannel.close();
-# ```
-#
-# + return - `io:Error` if any error occurred
+    # Closes a given `CSVChannel`.
+    # ```ballerina
+    # io:Error? err = readableCSVChannel.close();
+    # ```
+    #
+    # + return - `io:Error` if any error occurred
     public function close() returns Error? {
         if(self.dc is ReadableTextRecordChannel){
             var result = <ReadableTextRecordChannel> self.dc;
@@ -96,15 +96,15 @@ public class ReadableCSVChannel {
         return ();
     }
 
-# Returns a table, which corresponds to the CSV records.
-# ```ballerina
-# var tblResult1 = readableCSVChannel.getTable(Employee);
-# var tblResult2 = readableCSVChannel.getTable(Employee, ["id", "name"]);
-# ```
-#
-# + structType - The object in which the CSV records should be deserialized
-# + fieldNames - The names of the fields used as the (composite)key of the table
-# + return - Table, which represents the CSV records or else an `io:Error`
+    # Returns a table, which corresponds to the CSV records.
+    # ```ballerina
+    # var tblResult1 = readableCSVChannel.getTable(Employee);
+    # var tblResult2 = readableCSVChannel.getTable(Employee, ["id", "name"]);
+    # ```
+    #
+    # + structType - The object in which the CSV records should be deserialized
+    # + fieldNames - The names of the fields used as the (composite)key of the table
+    # + return - Table, which represents the CSV records or else an `io:Error`
     public function getTable(typedesc<record {}> structType, string[] fieldNames = [])
     returns @tainted table<record {}>|Error {
         return getTableExtern(self, structType, fieldNames);

--- a/io-ballerina/src/io/readable_data_channel.bal
+++ b/io-ballerina/src/io/readable_data_channel.bal
@@ -29,93 +29,93 @@ public class ReadableDataChannel {
         initReadableDataChannel(self, byteChannel, temp);
     }
 
-# Reads a 16 bit integer.
-# ```ballerina
-# int|io:Error result = dataChannel.readInt16();
-# ```
-# 
-# + return - The value of the integer, which is read or else an `io:Error` if any error occurred
+    # Reads a 16 bit integer.
+    # ```ballerina
+    # int|io:Error result = dataChannel.readInt16();
+    # ```
+    #
+    # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
     public function readInt16() returns int|Error {
         return readInt16Extern(self);
     }
 
-# Reads a 32 bit integer.
-# ```ballerina
-# int|io:Error result = dataChannel.readInt32();
-# ```
-# 
-# + return - The value of the integer, which is read or else an `io:Error` if any error occurred
+    # Reads a 32 bit integer.
+    # ```ballerina
+    # int|io:Error result = dataChannel.readInt32();
+    # ```
+    #
+    # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
     public function readInt32() returns int|Error {
         return readInt32Extern(self);
     }
 
-# Reads a 64 bit integer.
-# ```ballerina
-# int|io:Error result = dataChannel.readInt64();
-# ```
-# 
-# + return - The value of the integer, which is read or else an `io:Error` if any error occurred
+    # Reads a 64 bit integer.
+    # ```ballerina
+    # int|io:Error result = dataChannel.readInt64();
+    # ```
+    #
+    # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
     public function readInt64() returns int|Error {
         return readInt64Extern(self);
     }
 
-# Reads a 32 bit float.
-# ```ballerina
-# float|io:Error result = dataChannel.readFloat32();
-# ```
-# 
-# + return - The value of the float which is read or else `io:Error` if any error occurred
+    # Reads a 32 bit float.
+    # ```ballerina
+    # float|io:Error result = dataChannel.readFloat32();
+    # ```
+    #
+    # + return - The value of the float which is read or else `io:Error` if any error occurred
     public function readFloat32() returns float|Error {
         return readFloat32Extern(self);
     }
 
-# Reads a 64 bit float.
-# ```ballerina
-# float|io:Error result = dataChannel.readFloat64();
-# ```
-# 
-# + return - The value of the float which is read or else `io:Error` if any error occurred
+    # Reads a 64 bit float.
+    # ```ballerina
+    # float|io:Error result = dataChannel.readFloat64();
+    # ```
+    #
+    # + return - The value of the float which is read or else `io:Error` if any error occurred
     public function readFloat64() returns float|Error {
         return readFloat64Extern(self);
     }
 
-# Reads a byte and convert its value to boolean.
-# ```ballerina
-# boolean|io:Error result = dataChannel.readBool();
-# ```
-# 
-# + return - boolean value which is read or else `io:Error` if any error occurred
+    # Reads a byte and convert its value to boolean.
+    # ```ballerina
+    # boolean|io:Error result = dataChannel.readBool();
+    # ```
+    #
+    # + return - boolean value which is read or else `io:Error` if any error occurred
     public function readBool() returns boolean|Error {
         return readBoolExtern(self);
     }
 
-# Reads the string value represented through the provided number of bytes.
-# ```ballerina
-# string|io:Error string = dataChannel.readString(10, "UTF-8");
-# ```
-# 
-# + nBytes - Specifies the number of bytes, which represents the string
-# + encoding - Specifies the char-set encoding of the string
-# + return - The value of the string or else `io:Error` if any error occurred
+    # Reads the string value represented through the provided number of bytes.
+    # ```ballerina
+    # string|io:Error string = dataChannel.readString(10, "UTF-8");
+    # ```
+    #
+    # + nBytes - Specifies the number of bytes, which represents the string
+    # + encoding - Specifies the char-set encoding of the string
+    # + return - The value of the string or else `io:Error` if any error occurred
     public function readString(int nBytes, string encoding) returns string|Error {
         return readStringExtern(self, nBytes, encoding);
     }
 
-# Reads a variable length integer.
-# ```ballerina
-# int|io:Error result = dataChannel.readVarInt();
-# ```
-# 
-# + return - The value of the integer which is read or else `io:Error` if any error occurred
+    # Reads a variable length integer.
+    # ```ballerina
+    # int|io:Error result = dataChannel.readVarInt();
+    # ```
+    #
+    # + return - The value of the integer which is read or else `io:Error` if any error occurred
     public function readVarInt() returns int|Error {
         return readVarIntExtern(self);
     }
 
-# Closes the data channel.
-# ```ballerina
-# io:Error? err = dataChannel.close();
-# ```
-# + return - `()` if the channel is closed successfully or else an `io:Error` if any error occurred
+    # Closes the data channel.
+    # ```ballerina
+    # io:Error? err = dataChannel.close();
+    # ```
+    # + return - `()` if the channel is closed successfully or else an `io:Error` if any error occurred
     public function close() returns Error? {
         return closeReadableDataChannelExtern(self);
     }

--- a/io-ballerina/src/io/readable_data_channel.bal
+++ b/io-ballerina/src/io/readable_data_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # Represents a data channel for reading data.
-public type ReadableDataChannel object {
+public class ReadableDataChannel {
 
     #Initializes the data channel.
     # 
@@ -119,56 +119,56 @@ public type ReadableDataChannel object {
     public function close() returns Error? {
         return closeReadableDataChannelExtern(self);
     }
-};
+}
 
 function initReadableDataChannel(ReadableDataChannel dataChannel, ReadableByteChannel byteChannel,
                                  string bOrder) = @java:Method {
     name: "initReadableDataChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readInt16Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt16",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readInt32Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt32",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readInt64Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt64",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readFloat32Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
     name: "readFloat32",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readFloat64Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
     name: "readFloat64",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readBoolExtern(ReadableDataChannel dataChannel) returns boolean|Error = @java:Method {
     name: "readBool",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readStringExtern(ReadableDataChannel dataChannel, int nBytes, string encoding)
                           returns string|Error = @java:Method {
     name: "readString",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function readVarIntExtern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readVarInt",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function closeReadableDataChannelExtern(ReadableDataChannel dataChannel) returns Error? = @java:Method {
     name: "closeDataChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/src/io/readable_record_channel.bal
+++ b/io-ballerina/src/io/readable_record_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # Represents a channel which will allow to read
-public type ReadableTextRecordChannel object {
+public class ReadableTextRecordChannel {
 
     private ReadableCharacterChannel charChannel;
     private string rs;
@@ -65,25 +65,25 @@ public type ReadableTextRecordChannel object {
     public function close() returns Error? {
         return closeReadableTextRecordChannelExtern(self);
     }
-};
+}
 
 function initReadableTextRecordChannel(ReadableTextRecordChannel textChannel, ReadableCharacterChannel charChannel,
                                        string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
 function hasNextExtern(ReadableTextRecordChannel textChannel) returns boolean = @java:Method {
     name: "hasNext",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
 function getNextExtern(ReadableTextRecordChannel textChannel) returns @tainted string[]|Error = @java:Method {
     name: "getNext",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
 function closeReadableTextRecordChannelExtern(ReadableTextRecordChannel textChannel) returns Error? = @java:Method {
     name: "close",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;

--- a/io-ballerina/src/io/readable_record_channel.bal
+++ b/io-ballerina/src/io/readable_record_channel.bal
@@ -36,32 +36,32 @@ public class ReadableTextRecordChannel {
         initReadableTextRecordChannel(self, charChannel, fs, rs, fmt);
     }
 
-# Checks whether there's a record left to be read.
-# ```ballerina
-# boolean hasNext = readableRecChannel.hasNext();
-# ```
-#
-# + return - True if there's a record left to be read
+    # Checks whether there's a record left to be read.
+    # ```ballerina
+    # boolean hasNext = readableRecChannel.hasNext();
+    # ```
+    #
+    # + return - True if there's a record left to be read
     public function hasNext() returns boolean {
         return hasNextExtern(self);
     }
 
-# Get the next record from the input/output resource.
-# ```ballerina
-# string[]|io:Error record = readableRecChannel.getNext();
-# ```
-#
-# + return - Set of fields included in the record or else `io:Error`
+    # Get the next record from the input/output resource.
+    # ```ballerina
+    # string[]|io:Error record = readableRecChannel.getNext();
+    # ```
+    #
+    # + return - Set of fields included in the record or else `io:Error`
     public function getNext() returns @tainted string[]|Error {
         return getNextExtern(self);
     }
 
-# Closes a given record channel.
-# ```ballerina
-# io:Error err = readableRecChannel.close();
-# ```
-#
-# + return - An `io:Error` if the record channel could not be closed properly
+    # Closes a given record channel.
+    # ```ballerina
+    # io:Error err = readableRecChannel.close();
+    # ```
+    #
+    # + return - An `io:Error` if the record channel could not be closed properly
     public function close() returns Error? {
         return closeReadableTextRecordChannelExtern(self);
     }

--- a/io-ballerina/src/io/strings.bal
+++ b/io-ballerina/src/io/strings.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 # Represents a reader which will wrap string content as a channel.
-public type StringReader object {
+public class StringReader {
     private ReadableCharacterChannel? charChannel;
 
     # Constructs a channel to read string.
@@ -87,4 +87,4 @@ public type StringReader object {
         }
         return ();
     }
-};
+}

--- a/io-ballerina/src/io/strings.bal
+++ b/io-ballerina/src/io/strings.bal
@@ -28,13 +28,13 @@ public class StringReader {
         self.charChannel = new ReadableCharacterChannel(byteChannel, encoding);
     }
 
-# Reads string as JSON using the reader.
-# ```ballerina
-# io:StringReader reader = new("{\"name\": \"Alice\"}");
-# json|io:Error? person = reader.readJson();
-# ```
-#
-# + return - JSON or else `io:Error` if any error occurred
+    # Reads string as JSON using the reader.
+    # ```ballerina
+    # io:StringReader reader = new("{\"name\": \"Alice\"}");
+    # json|io:Error? person = reader.readJson();
+    # ```
+    #
+    # + return - JSON or else `io:Error` if any error occurred
     public function readJson() returns @tainted json|Error {
         if(self.charChannel is ReadableCharacterChannel){
             var result = <ReadableCharacterChannel> self.charChannel;
@@ -43,13 +43,13 @@ public class StringReader {
         return ();
     }
 
-# Reads a string as XML using the reader.
-# ```ballerina
-# io:StringReader reader = new("<Person><Name>Alice</Name></Person>");
-# xml|io:Error? person = reader.readXml();
-# ```
-# 
-# + return - XML or else `io:Error` if any error occurred
+    # Reads a string as XML using the reader.
+    # ```ballerina
+    # io:StringReader reader = new("<Person><Name>Alice</Name></Person>");
+    # xml|io:Error? person = reader.readXml();
+    # ```
+    #
+    # + return - XML or else `io:Error` if any error occurred
     public function readXml() returns @tainted xml|Error? {
         if(self.charChannel is ReadableCharacterChannel){
             var result = <ReadableCharacterChannel> self.charChannel;
@@ -58,14 +58,14 @@ public class StringReader {
         return ();
     }
 
-# Reads the characters from the given string.
-# ```ballerina
-# io:StringReader reader = new("Some text");
-# string|io:Error? person = reader.readChar(4);
-# ```
-#
-# + nCharacters - Number of characters to be read
-# + return - String or else `io:Error` if any error occurred
+    # Reads the characters from the given string.
+    # ```ballerina
+    # io:StringReader reader = new("Some text");
+    # string|io:Error? person = reader.readChar(4);
+    # ```
+    #
+    # + nCharacters - Number of characters to be read
+    # + return - String or else `io:Error` if any error occurred
     public function readChar(int nCharacters) returns @tainted string|Error? {
         if(self.charChannel is ReadableCharacterChannel){
             var result = <ReadableCharacterChannel> self.charChannel;
@@ -74,12 +74,12 @@ public class StringReader {
         return ();
     }
 
-# Closes the reader.
-# ```ballerina
-# io:Error? err = reader.close();
-# ```
-#
-# + return - An `io:Error` if could not close the channel or else `()`.
+    # Closes the reader.
+    # ```ballerina
+    # io:Error? err = reader.close();
+    # ```
+    #
+    # + return - An `io:Error` if could not close the channel or else `()`.
     public function close() returns Error? {
         if(self.charChannel is ReadableCharacterChannel){
             var result = <ReadableCharacterChannel> self.charChannel;

--- a/io-ballerina/src/io/tests/unit-tests/io-test.bal
+++ b/io-ballerina/src/io/tests/unit-tests/io-test.bal
@@ -247,7 +247,7 @@ function testSprintfArray() {
     string fmtStr = "%s";
     int[] arr = [111, 222, 333];
     string output = sprintf(fmtStr, arr);
-    test:assertEquals(output, "111 222 333");
+    test:assertEquals(output, "[111,222,333]");
 }
 
 @test:Config{
@@ -347,23 +347,23 @@ function func1(int a, int b) returns (int) {
     return c;
 }
 
-type Foo object {
+class Foo {
     function bar() returns (int) {
         return 5;
     }
-};
+}
 
 public function initOutputStream() = @java:Method {
     name: "initOutputStream",
-    class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
+    'class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
 } external;
 
 public function readOutputStream() returns string = @java:Method {
     name: "readOutputStream",
-    class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
+    'class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
 } external;
 
 public function resetOutputStream() = @java:Method {
     name: "resetOutputStream",
-    class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
+    'class: "org.ballerinalang.stdlib.io.testutils.PrintTestUtils"
 } external;

--- a/io-ballerina/src/io/writable_byte_channel.bal
+++ b/io-ballerina/src/io/writable_byte_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # WritableByteChannel represents an output resource (i.e file). which could be used to sink bytes.
-public type WritableByteChannel object {
+public class WritableByteChannel {
 
     # Adding default init function to prevent object getting initialized from the user code.
     function init() {}
@@ -45,14 +45,14 @@ public type WritableByteChannel object {
     public function close() returns Error? {
         return closeWritableByteChannelExtern(self);
     }
-};
+}
 
 function byteWriteExtern(WritableByteChannel byteChannel, byte[] content, int offset) returns int|Error = @java:Method {
     name: "write",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
 function closeWritableByteChannelExtern(WritableByteChannel byteChannel) returns Error? = @java:Method {
     name: "closeByteChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;

--- a/io-ballerina/src/io/writable_byte_channel.bal
+++ b/io-ballerina/src/io/writable_byte_channel.bal
@@ -22,26 +22,26 @@ public class WritableByteChannel {
     # Adding default init function to prevent object getting initialized from the user code.
     function init() {}
 
-# Sinks bytes from a given input/output resource.
-#
-# This operation will be asynchronous. Writing might return without writing all the content.
-# ```ballerina
-# int|io:Error result = writableByteChannel.write(record, 0);
-# ```
-#
-# + content - Block of bytes, which should be written
-# + offset - Offset, which should be kept when writing bytes.
-# + return - Number of bytes written or else `io:Error`
+    # Sinks bytes from a given input/output resource.
+    #
+    # This operation will be asynchronous. Writing might return without writing all the content.
+    # ```ballerina
+    # int|io:Error result = writableByteChannel.write(record, 0);
+    # ```
+    #
+    # + content - Block of bytes, which should be written
+    # + offset - Offset, which should be kept when writing bytes.
+    # + return - Number of bytes written or else `io:Error`
     public function write(byte[] content, int offset) returns int|Error {
         return byteWriteExtern(self, content, offset);
     }
 
-# Closes a given byte channel.
-# ```ballerina
-# io:Error err = writableByteChannel.close();
-# ```
-#
-# + return - `io:Error` or else `()`
+    # Closes a given byte channel.
+    # ```ballerina
+    # io:Error err = writableByteChannel.close();
+    # ```
+    #
+    # + return - `io:Error` or else `()`
     public function close() returns Error? {
         return closeWritableByteChannelExtern(self);
     }

--- a/io-ballerina/src/io/writable_character_channel.bal
+++ b/io-ballerina/src/io/writable_character_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # Represents a channel which could be used to write characters through a given WritableCharacterChannel.
-public type WritableCharacterChannel object {
+public class WritableCharacterChannel {
 
     private WritableByteChannel bChannel;
     private string charset;
@@ -86,37 +86,37 @@ public type WritableCharacterChannel object {
     public function close() returns Error? {
         return closeWritableCharacterChannel(self);
     }
-};
+}
 
 function initWritableCharacterChannel(WritableCharacterChannel characterChannel, WritableByteChannel byteChannel,
                                       string charset) = @java:Method {
     name: "initCharacterChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function writeExtern(WritableCharacterChannel characterChannel, string content, int startOffset)
                      returns int|Error = @java:Method {
     name: "write",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function writeJsonExtern(WritableCharacterChannel characterChannel, json content) returns Error? = @java:Method {
     name: "writeJson",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function writeXmlExtern(WritableCharacterChannel characterChannel, xml content) returns Error? = @java:Method {
     name: "writeXml",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties,
                                 string comment) returns Error? = @java:Method {
     name: "writeProperties",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
 function closeWritableCharacterChannel(WritableCharacterChannel characterChannel) returns Error? = @java:Method {
     name: "close",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/src/io/writable_csv_channel.bal
+++ b/io-ballerina/src/io/writable_csv_channel.bal
@@ -28,7 +28,7 @@ public const int MINIMUM_HEADER_COUNT = 0;
 
 
 # Represents a WritableCSVChannel, which could be used to write records from the CSV file.
-public type WritableCSVChannel object {
+public class WritableCSVChannel {
     private WritableTextRecordChannel? dc;
 
     # Constructs a CSV channel from a `CharacterChannel` to read/write CSV records.
@@ -75,4 +75,4 @@ public type WritableCSVChannel object {
         }
         return ();
     }
-};
+}

--- a/io-ballerina/src/io/writable_csv_channel.bal
+++ b/io-ballerina/src/io/writable_csv_channel.bal
@@ -47,13 +47,13 @@ public class WritableCSVChannel {
         }
     }
 
-# Writes the record to a given CSV file.
-# ```ballerina
-# io:Error err = csvChannel.write(record);
-# ```
-# 
-# + csvRecord - A record to be written to the channel
-# + return - An `io:Error` if the record could not be written properly
+    # Writes the record to a given CSV file.
+    # ```ballerina
+    # io:Error err = csvChannel.write(record);
+    # ```
+    #
+    # + csvRecord - A record to be written to the channel
+    # + return - An `io:Error` if the record could not be written properly
     public function write(string[] csvRecord) returns Error? {
         if(self.dc is WritableTextRecordChannel){
             var result = <WritableTextRecordChannel> self.dc;
@@ -62,12 +62,12 @@ public class WritableCSVChannel {
         return ();
     }
 
-# Closes a given `CSVChannel`.
-# ```ballerina
-# io:Error? err = csvChannel.close();
-# ```
-# 
-# + return - `()` or else `io:Error` if any error occurred
+    # Closes a given `CSVChannel`.
+    # ```ballerina
+    # io:Error? err = csvChannel.close();
+    # ```
+    #
+    # + return - `()` or else `io:Error` if any error occurred
     public function close() returns Error? {
         if(self.dc is WritableTextRecordChannel){
             var result = <WritableTextRecordChannel> self.dc;

--- a/io-ballerina/src/io/writable_data_channel.bal
+++ b/io-ballerina/src/io/writable_data_channel.bal
@@ -42,101 +42,101 @@ public class WritableDataChannel {
         initWritableDataChannel(self, byteChannel, temp);
     }
 
-# Writes a 16 bit integer.
-# ```ballerina
-# io:Error? err = dataChannel.writeInt16(length);
-# ```
-#
-# + value - The integer, which will be written
-# + return - `()` if the content is written successfully or else an `io:Error` if any error occurred
+    # Writes a 16 bit integer.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeInt16(length);
+    # ```
+    #
+    # + value - The integer, which will be written
+    # + return - `()` if the content is written successfully or else an `io:Error` if any error occurred
     public function writeInt16(int value) returns Error? {
         return writeInt16Extern(self, value);
     }
 
-# Writes a 32 bit integer.
-# ```ballerina
-# io:Error? err = dataChannel.writeInt32(length);
-# ```
-# 
-# + value - The integer, which will be written
-# + return - `()` if the content is written successfully or else `io:Error` if any error occurred
+    # Writes a 32 bit integer.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeInt32(length);
+    # ```
+    #
+    # + value - The integer, which will be written
+    # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
     public function writeInt32(int value) returns Error? {
         return writeInt32Extern(self, value);
     }
 
-# Writes a 64 bit integer.
-# ```ballerina
-# io:Error? err = dataChannel.writeInt64(length);
-# ```
-#
-# + value - The integer, which will be written
-# + return - `()` if the content is written successfully or else `io:Error` if any error occurred
+    # Writes a 64 bit integer.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeInt64(length);
+    # ```
+    #
+    # + value - The integer, which will be written
+    # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
     public function writeInt64(int value) returns Error? {
         return writeInt64Extern(self, value);
     }
 
-# Writes a 32 bit float.
-# ```ballerina
-# io:Error? err = dataChannel.writeFloat32(3.12);
-# ```
-#
-# + value - The float, which will be written
-# + return - `()` if the float is written successfully or else `io:Error` if any error occurred
+    # Writes a 32 bit float.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeFloat32(3.12);
+    # ```
+    #
+    # + value - The float, which will be written
+    # + return - `()` if the float is written successfully or else `io:Error` if any error occurred
     public function writeFloat32(float value) returns Error? {
         return writeFloat32Extern(self, value);
     }
 
-# Writes a 64 bit float.
-# ```ballerina
-# io:Error? err = dataChannel.writeFloat32(3.12);
-# ```
-#
-# + value - The float, which will be written
-# + return - `()` if the float is written successfully or else `io:Error` if any error occurred
+    # Writes a 64 bit float.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeFloat32(3.12);
+    # ```
+    #
+    # + value - The float, which will be written
+    # + return - `()` if the float is written successfully or else `io:Error` if any error occurred
     public function writeFloat64(float value) returns Error? {
         return writeFloat64Extern(self, value);
     }
 
-# Writes a boolean.
-# ```ballerina
-# io:Error? err = dataChannel.writeInt64(length);
-# ```
-#
-# + value - The boolean, which will be written
-# + return - `()` if the content is written successfully or else `io:Error` if any error occurred
+    # Writes a boolean.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeInt64(length);
+    # ```
+    #
+    # + value - The boolean, which will be written
+    # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
     public function writeBool(boolean value) returns Error? {
         return writeBoolExtern(self, value);
     }
 
-# Writes a given string value to the respective channel.
-# ```ballerina
-# io:Error? err = dataChannel.writeString(record);
-# ```
-#
-# + value - The value, which should be written
-# + encoding - The encoding, which will represent the value string
-# + return - `()` if the content is written successfully or else `io:Error` if any error occurred
+    # Writes a given string value to the respective channel.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeString(record);
+    # ```
+    #
+    # + value - The value, which should be written
+    # + encoding - The encoding, which will represent the value string
+    # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
     public function writeString(string value, string encoding) returns Error? {
         return writeStringExtern(self, value, encoding);
     }
 
-# Writes a variable-length integer.
-# ```ballerina
-# io:Error? err = dataChannel.writeVarInt(length);
-# ```
-#
-# + value - The int, which will be written
-# + return - The value of the integer, which is written or else `io:Error` if any error occurred
+    # Writes a variable-length integer.
+    # ```ballerina
+    # io:Error? err = dataChannel.writeVarInt(length);
+    # ```
+    #
+    # + value - The int, which will be written
+    # + return - The value of the integer, which is written or else `io:Error` if any error occurred
     public function writeVarInt(int value) returns Error? {
         return writeVarIntExtern(self, value);
     }
 
-# Closes the data channel.
-# ```ballerina
-# io:Error? err = dataChannel.close();
-# ```
-#
-# + return - `()` if the channel is closed successfully or else `io:Error` if any error occurred
+    # Closes the data channel.
+    # ```ballerina
+    # io:Error? err = dataChannel.close();
+    # ```
+    #
+    # + return - `()` if the channel is closed successfully or else `io:Error` if any error occurred
     public function close() returns Error? {
         return closeWritableDataChannelExtern(self);
     }

--- a/io-ballerina/src/io/writable_data_channel.bal
+++ b/io-ballerina/src/io/writable_data_channel.bal
@@ -30,7 +30,7 @@ public const BIG_ENDIAN = "BE";
 public const LITTLE_ENDIAN = "LE";
 
 # Represents a WritableDataChannel for writing data.
-public type WritableDataChannel object {
+public class WritableDataChannel {
 
     # Initializes data channel.
     #
@@ -140,56 +140,56 @@ public type WritableDataChannel object {
     public function close() returns Error? {
         return closeWritableDataChannelExtern(self);
     }
-};
+}
 
 function initWritableDataChannel(WritableDataChannel dataChannel, WritableByteChannel byteChannel,
                                  string bOrder) = @java:Method {
     name: "initWritableDataChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeInt16Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt16",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeInt32Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt32",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeInt64Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt64",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeFloat32Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
     name: "writeFloat32",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeFloat64Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
     name: "writeFloat64",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeBoolExtern(WritableDataChannel dataChannel, boolean value) returns Error? = @java:Method {
     name: "writeBool",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeStringExtern(WritableDataChannel dataChannel, string value, string encoding)
                            returns Error? = @java:Method {
     name: "writeString",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function writeVarIntExtern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeVarInt",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
 function closeWritableDataChannelExtern(WritableDataChannel dataChannel) returns Error? = @java:Method {
     name: "closeDataChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/src/io/writable_record_channel.bal
+++ b/io-ballerina/src/io/writable_record_channel.bal
@@ -39,23 +39,23 @@ public class WritableTextRecordChannel {
         initWritableTextRecordChannel(self, characterChannel, fs, rs, fmt);
     }
 
-# Writes records to a given output resource.
-# ```ballerina
-# io:Error? err = writableChannel.write(records);
-# ```
-# 
-# + textRecord - List of fields to be written
-# + return - An `io:Error` if the records could not be written properly or else `()`
+    # Writes records to a given output resource.
+    # ```ballerina
+    # io:Error? err = writableChannel.write(records);
+    # ```
+    #
+    # + textRecord - List of fields to be written
+    # + return - An `io:Error` if the records could not be written properly or else `()`
     public function write(string[] textRecord) returns Error? {
         return writeRecordExtern(self, textRecord);
     }
 
-# Closes a given record channel.
-# ```ballerina
-# io:Error? err = writableChannel.close();
-# ```
-# 
-# + return - An `io:Error` if the record channel could not be closed properly or else `()`
+    # Closes a given record channel.
+    # ```ballerina
+    # io:Error? err = writableChannel.close();
+    # ```
+    #
+    # + return - An `io:Error` if the record channel could not be closed properly or else `()`
     public function close() returns Error? {
         return closeWritableTextRecordChannelExtern(self);
     }

--- a/io-ballerina/src/io/writable_record_channel.bal
+++ b/io-ballerina/src/io/writable_record_channel.bal
@@ -17,7 +17,7 @@
 import ballerina/java;
 
 # Represents a channel, which will allow to write records through a given WritableCharacterChannel.
-public type WritableTextRecordChannel object {
+public class WritableTextRecordChannel {
     private WritableCharacterChannel characterChannel;
     private string fs;
     private string rs;
@@ -59,20 +59,20 @@ public type WritableTextRecordChannel object {
     public function close() returns Error? {
         return closeWritableTextRecordChannelExtern(self);
     }
-};
+}
 
 function initWritableTextRecordChannel(WritableTextRecordChannel textChannel, WritableCharacterChannel charChannel,
                                        string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
 function writeRecordExtern(WritableTextRecordChannel textChannel, string[] textRecord) returns Error? = @java:Method {
     name: "write",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
 function closeWritableTextRecordChannelExtern(WritableTextRecordChannel textChannel) returns Error? = @java:Method {
     name: "close",
-    class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
+    'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;

--- a/io-native/build.gradle
+++ b/io-native/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
     compile group: 'org.ballerinalang', name: 'ballerina-core', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-runtime-api', version: "${ballerinaLangVersion}"
+    compile group: 'org.ballerinalang', name: 'ballerina-rt', version: "${ballerinaLangVersion}"
     compile group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
     compile group: 'commons-codec', name: 'commons-codec', version: '1.9'
     compile 'org.testng:testng:6.14.3'

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/PrintUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/PrintUtils.java
@@ -40,7 +40,7 @@ public class PrintUtils {
         }
         for (Object value : values) {
             if (value != null) {
-                out.print(StringUtils.getStringValue(value));
+                out.print(StringUtils.getStringValue(value, null));
             }
         }
     }
@@ -54,7 +54,7 @@ public class PrintUtils {
         StringBuilder content = new StringBuilder();
         for (Object value : values) {
             if (value != null) {
-                content.append(StringUtils.getStringValue(value));
+                content.append(StringUtils.getStringValue(value, null));
             }
         }
         out.println(content);

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/Sprintf.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/Sprintf.java
@@ -109,7 +109,7 @@ public class Sprintf {
                             break;
                         case 's':
                             if (ref != null) {
-                                result.append(String.format("%" + padding + "s", StringUtils.getStringValue(ref)));
+                                result.append(String.format("%" + padding + "s", StringUtils.getStringValue(ref, null)));
                             }
                             break;
                         case '%':


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Add class support
- Indent API doc comments

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/25637

## Test environment
- SLP4
- Java 8
- macOS