### PR TITLE
Update build and workflow scripts for releasing and publishing

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -23,7 +23,6 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  repository_dispatch:
+    types: [ stdlib-publish-snapshot ]
   push:
     branches:
       - master
@@ -20,9 +22,20 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_PAT }}
         run: |
           ./gradlew publish --scan
-          
+      - name: Dispatch Dependent Module Builds
+        if: github.event.action != 'stdlib-publish-snapshot'
+        run: |
+          echo "Triggering dependent module builds..." && \
+          curl -X POST https://api.github.com/repos/ballerina-platform/ThisaruGuruge/dispatches \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          --data '{
+            "event_type": "stdlib-module-push",
+            "client_payload": {
+              "module": "${{ github.repository }}"
+            }
+          }'

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -31,9 +31,9 @@ jobs:
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |
           echo "Triggering dependent module builds..." && \
-          curl -X POST https://api.github.com/repos/ballerina-platform/ThisaruGuruge/dispatches \
+          curl -u ${{ secrets.BALLERINA_BOT_USERNAME }} -X POST https://api.github.com/repos/ThisaruGuruge/ballerina-lang/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
-          -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          -H 'Authorization: token ${{ secrets.BALLERINA_BOT_PAT }}' \
           --data '{
             "event_type": "stdlib-module-push",
             "client_payload": {

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -24,16 +24,17 @@ jobs:
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_PAT }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew publish --scan
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |
           echo "Triggering dependent module builds..." && \
-          curl -u ${{ secrets.BALLERINA_BOT_USERNAME }} -X POST https://api.github.com/repos/ThisaruGuruge/ballerina-lang/dispatches \
+          curl -u ${{ secrets.BALLERINA_BOT_USERNAME }} -X POST \
+          https://api.github.com/repos/ballerina-platform/ballerina-lang/dispatches \
           -H 'Accept: application/vnd.github.v3+json' \
-          -H 'Authorization: token ${{ secrets.BALLERINA_BOT_PAT }}' \
+          -H 'Authorization: token ${{ secrets.BALLERINA_BOT_TOKEN }}' \
           --data '{
             "event_type": "stdlib-module-push",
             "client_payload": {

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -23,6 +23,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,7 +17,6 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew build --scan
@@ -34,7 +33,6 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew.bat build -x test --scan

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,9 +17,9 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew build --scan
 
   windows-build:
@@ -34,8 +34,8 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew.bat build -x test --scan
         

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,10 +1,14 @@
 name: Publish release
 
-on: [workflow_dispatch, repository_dispatch]
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ stdlib-release-pipeline ]
 
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'ballerina-platform'
 
     steps:
       - uses: actions/checkout@v2
@@ -31,8 +35,8 @@ jobs:
       - name: Publish artifact
         env:
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew release -Prelease.useAutomaticVersion=true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,6 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew build --scan
@@ -32,7 +31,6 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew.bat build -x test --scan

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,9 +15,9 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew build --scan
 
   windows-build:
@@ -32,8 +32,8 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew.bat build -x test --scan
         

--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,6 @@ allprojects {
         }
 
         maven {
-            url = 'https://maven.wso2.org/nexus/content/repositories/orgballerinalang-1614'
-        }
-
-        maven {
             url = 'https://repo.maven.apache.org/maven2'
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ allprojects {
 
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-io'
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,14 @@ allprojects {
         }
 
         maven {
+            url = 'https://maven.pkg.github.com/ballerina-platform/ballerina-lang'
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
+        }
+
+        maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-io'
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=0.5.0-SNAPSHOT
-ballerinaLangVersion=2.0.0-Preview4-SNAPSHOT
+ballerinaLangVersion=2.0.0-Preview5-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=0.5.0-SNAPSHOT
+version=0.5.1-SNAPSHOT
 ballerinaLangVersion=2.0.0-Preview5-SNAPSHOT

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOConstants.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOConstants.java
@@ -53,7 +53,7 @@ public class IOConstants {
      */
     public static final int CHANNEL_BUFFER_SIZE = 16384;
 
-    public static final String IO_PACKAGE_VERSION =  "0.5.0";
+    public static final String IO_PACKAGE_VERSION =  "0.5.1";
 
     public static final BPackage IO_PACKAGE_ID = new BPackage(BALLERINA_BUILTIN_PKG_PREFIX, "io", IO_PACKAGE_VERSION);
 


### PR DESCRIPTION
## Purpose
As a part of standard library migration, the standard library module `SNAPSHOT` artifacts will be published to Github. This PR will enable the following:

- When there is an event of pushing changes to the `ballerina-lang` `master` branch, master branch build will be triggered eventually, and the `SNAPSHOT` artifacts will be published to the Github.
- When there is an event of a push the `master` branch in a module, on which this module depends on (if there's any), this module `master` branch build will be triggered and the `SNAPSHOT` artifacts will be published.
- When there is an event of a push on the `master` branch of this module, all the modules depending on this module will be triggered and the `SNAPSHOT` artifacts will be published.

Additionally this PR will restrict the release functionality to the `upstream` repository, and also adds `ballerina-lang` Github packages dependency in the `build.gradle` file. 