### PR TITLE
Add balJavaDebug option

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,4 +56,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          bin/hub pull-request -m "[Automated] Sync master after "$VERSION" release
+          bin/hub pull-request -m "[Automated] Sync master after "$VERSION" release"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,4 +56,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          bin/hub pull-request -m "[Automated] Sync master after "$VERSION" release"
+          bin/hub pull-request -m "[Automated] Sync master after $VERSION release"

--- a/README.md
+++ b/README.md
@@ -27,21 +27,28 @@ For example demonstrations of the usage, go to [Ballerina By Examples](https://b
 Execute the commands below to build from source.
 
 1. To build the library:
-        
-        ./gradlew clean build
+   ```    
+   ./gradlew clean build
+   ```
 
-2. To run the integration tests:
-
-        ./gradlew clean test
-
-3. To build the module without the tests:
-
-        ./gradlew clean build -x test
-
-4. To debug the tests:
-
-        ./gradlew clean build -Pdebug=<port>
-
+1. To run the integration tests:
+   ```
+   ./gradlew clean test
+   ```
+1. To build the module without the tests:
+   ```
+   ./gradlew clean build -x test
+   ```
+1. To debug module implementation:
+   ```
+   ./gradlew clean build -Pdebug=<port>
+   ./gradlew clean test -Pdebug=<port>
+   ```
+1. To debug the module with Ballerina language:
+   ```
+   ./gradlew clean build -PbalJavaDebug=<port>
+   ./gradlew clean test -PbalJavaDebug=<port>
+   ```
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -90,14 +90,19 @@ task ballerinaTest {
         debugParams = "--debug ${project.findProperty("debug")}"
     }
 
+    def balJavaDebugParam = ""
+    if (project.hasProperty("balJavaDebug")) {
+        balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
+    }
+
     doLast {
         exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --all ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/ballerina.bat test --all ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --all ${debugParams}"
+                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/ballerina test --all ${debugParams}"
             }
         }
     }


### PR DESCRIPTION
## Purpose
There are 2 types of debug options we need to cover in standard libraries.
1. Debug a standard library with the native Java code
1. Debug a standard library with the Ballerina language

The `-Pdebug=5005` option, we previously had covered the 1st point. Here we enabled `-PbalJavaDebug=5005` covers the second point.

Address the issue in this thread: https://ballerina-platform.slack.com/archives/C9WMA6QDC/p1600844347001800
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
- Enabled -PbalJavaDebug option
- Minor fix to the release action

## Test environment
- SLP5
- Java8
- macOS
 