### PR TITLE
Fix Block accessibility and BufferedInputStream issues

### DIFF
--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -182,16 +182,18 @@ task ballerinaBuild {
             }
 
         }
-        // Doc creation and packing
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat doc ${moduleName} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina doc ${moduleName}"
-            }
-        }
+//        Disabling doc creation due to this issue(https://github.com/ballerina-platform/ballerina-lang/issues/26733).
+//        Once it fixed, we can enable doc creation.
+//        // Doc creation and packing
+//        exec {
+//            workingDir project.projectDir
+//            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+//            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+//                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat doc ${moduleName} && exit %%ERRORLEVEL%%"
+//            } else {
+//                commandLine 'sh', '-c', "$distributionBinPath/ballerina doc ${moduleName}"
+//            }
+//        }
         copy {
             from file("$project.projectDir/target/apidocs/${moduleName}")
             into file("$project.projectDir/build/docs_parent/docs/${moduleName}")

--- a/io-ballerina/src/io/bytes/block_stream.bal
+++ b/io-ballerina/src/io/bytes/block_stream.bal
@@ -16,7 +16,7 @@
 
 import ballerina/java;
 
-type Block readonly & byte[];
+public type Block readonly & byte[];
 
 # BlockStream used to initialize a byte stream.
 public class BlockStream {

--- a/io-ballerina/src/io/record/file_csv_io.bal
+++ b/io-ballerina/src/io/record/file_csv_io.bal
@@ -53,7 +53,6 @@ public function fileReadCsvAsStream(@untainted string path) returns @tainted str
 # ```
 # + path - File path
 # + content - CSV content as an array of string arrays
-# + skipHeaders - Number of headers, which should be skipped
 # + return - `io:Error` or else `()`
 public function fileWriteCsv(@untainted string path, string[][] content) returns Error? {
     var csvChannel = openWritableCsvFile(path);

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
@@ -87,8 +87,8 @@ public class ByteChannelUtils extends AbstractNativeChannel {
     }
 
     public static Object readAll(BObject channel) {
-        BufferedInputStream bufferedInputStream = getBufferedInputStream(channel);
         try {
+            BufferedInputStream bufferedInputStream = getBufferedInputStream(channel);
             if (bufferedInputStream != null) {
                 return ValueCreator.createArrayValue(bufferedInputStream.readAllBytes());
             }
@@ -99,10 +99,10 @@ public class ByteChannelUtils extends AbstractNativeChannel {
     }
 
     public static Object readBlock(BObject channel, long blockSize) {
-        BufferedInputStream bufferedInputStream = getBufferedInputStream(channel);
         int blockSizeInt = (int) blockSize;
         byte[] buffer = new byte[blockSizeInt];
         try {
+            BufferedInputStream bufferedInputStream = getBufferedInputStream(channel);
             if (bufferedInputStream != null) {
                 int n = bufferedInputStream.read(buffer, 0, blockSizeInt);
                 if (n == -1) {
@@ -248,10 +248,17 @@ public class ByteChannelUtils extends AbstractNativeChannel {
         return content;
     }
 
-    private static BufferedInputStream getBufferedInputStream(BObject channel) {
+    private static BufferedInputStream getBufferedInputStream(BObject channel) throws IOException {
         if (channel.getNativeData(IOConstants.BUFFERED_INPUT_STREAM_ENTRY) != null) {
             return (BufferedInputStream) channel.getNativeData(IOConstants.BUFFERED_INPUT_STREAM_ENTRY);
+        } else {
+            Channel byteChannel = (Channel) channel.getNativeData(BYTE_CHANNEL_NAME);
+            BufferedInputStream bufferedInputStream = new BufferedInputStream(byteChannel.getInputStream());
+            channel.addNativeData(
+                    IOConstants.BUFFERED_INPUT_STREAM_ENTRY,
+                    bufferedInputStream
+            );
+            return bufferedInputStream;
         }
-        return null;
     }
 }


### PR DESCRIPTION
## Purpose
$subject

## Goals
To successfully make I/O operations from a socket channel.

## Approach
- Make Block type public
- Create a BufferedInputStream when unavailable during byte operations
- Disable doc creation temporary due to this issue(https://github.com/ballerina-platform/ballerina-lang/issues/26733). Once it fixed, we can enable doc creation again.

## Test environment
- macOS
- Java 11
- SLP 6
 