### PR TITLE
Minor API fixes with returning nulls and taint checking

### DIFF
--- a/io-ballerina/src/io/bytes/channel_byte_io.bal
+++ b/io-ballerina/src/io/bytes/channel_byte_io.bal
@@ -41,7 +41,7 @@ public function channelReadBytes(ReadableChannel readableChannel) returns @taint
 # + readableChannel - A readable channel
 # + blockSize - An optional size of the byte block. Default size is 4KB.
 # + return - Either a byte block stream or `io:Error`
-public function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns stream<byte[]>|Error? {
+public function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns @tainted stream<Block>|Error {
     if (readableChannel is ReadableByteChannel) {
         return readableChannel.blockStream(blockSize);
     } else {

--- a/io-ballerina/src/io/bytes/file_byte_io.bal
+++ b/io-ballerina/src/io/bytes/file_byte_io.bal
@@ -36,7 +36,7 @@ public function fileReadBytes(@untainted string path) returns @tainted readonly 
 # + path - File path
 # + blockSize - Block size
 # + return - Either a byte block stream or `io:Error`
-public function fileReadBlocksAsStream(string path, int blockSize) returns stream<byte[]>|Error? {
+public function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadBlocksAsStream(byteChannel, blockSize);

--- a/io-ballerina/src/io/bytes/readable_byte_channel.bal
+++ b/io-ballerina/src/io/bytes/readable_byte_channel.bal
@@ -57,7 +57,7 @@ public class ReadableByteChannel {
     # ```
     # + blockSize - A positive integer. Size of the block.
     # + return - Either a block stream or else an `io:Error`
-    public function blockStream(int blockSize) returns stream<Block>|Error? {
+    public function blockStream(int blockSize) returns @tainted stream<Block>|Error {
         BlockStream blockStream = new (self, blockSize);
         return new stream<Block>(blockStream);
     }

--- a/io-ballerina/src/io/character/channel_string_io.bal
+++ b/io-ballerina/src/io/character/channel_string_io.bal
@@ -56,7 +56,7 @@ public function channelReadLines(ReadableChannel readableChannel) returns @taint
 # ```
 # + readableChannel - A readable channel
 # + return - Either a string array or `io:Error`
-public function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error? {
+public function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         return characterChannel.lineStream();
@@ -135,10 +135,9 @@ public function channelWriteString(WritableChannel writableChannel, string conte
 public function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
-        string[] reversedContent = content.reverse();
         string writeContent = "";
-        foreach string line in reversedContent {
-            writeContent = line + NEW_LINE;
+        foreach string line in content {
+            writeContent = writeContent + line + NEW_LINE;
         }
         var writeResult = characterChannel.write(writeContent, 0);
         if (writeResult is Error) {

--- a/io-ballerina/src/io/character/file_string_io.bal
+++ b/io-ballerina/src/io/character/file_string_io.bal
@@ -50,7 +50,7 @@ public function fileReadLines(@untainted string path) returns @tainted string[]|
 # ```
 # + path - File path
 # + return - Either a string array or `io:Error`
-public function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string>|Error? {
+public function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadLinesAsStream(byteChannel);

--- a/io-ballerina/src/io/character/readable_character_channel.bal
+++ b/io-ballerina/src/io/character/readable_character_channel.bal
@@ -99,7 +99,7 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - Either a stream of strings(lines) or an io:Error.
-    public function lineStream() returns stream<string>|Error? {
+    public function lineStream() returns stream<string>|Error {
         LineStream lineStream = new (self);
         return new stream<string>(lineStream);
     }

--- a/io-ballerina/src/io/record/channel_csv_io.bal
+++ b/io-ballerina/src/io/record/channel_csv_io.bal
@@ -52,7 +52,7 @@ public function channelReadCsv(ReadableChannel readableChannel, int skipHeaders 
 # ```
 # + readableChannel - A readable channel
 # + return - Either a stream of string array or `io:Error`
-public function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error? {
+public function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, 0);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();

--- a/io-ballerina/src/io/record/file_csv_io.bal
+++ b/io-ballerina/src/io/record/file_csv_io.bal
@@ -37,7 +37,7 @@ public function fileReadCsv(@untainted string path, int skipHeaders = 0) returns
 # ```
 # + path - File path
 # + return - Either a stream of string array or `io:Error`
-public function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[]>|Error? {
+public function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[]>|Error {
     var csvChannel = openReadableCsvFile(path);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();

--- a/io-ballerina/src/io/record/readable_csv_channel.bal
+++ b/io-ballerina/src/io/record/readable_csv_channel.bal
@@ -88,7 +88,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - Either a stream of records(string[]) or else an `io:Error`
-    public function csvStream() returns stream<string[]>|Error? {
+    public function csvStream() returns stream<string[]>|Error {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
             CSVStream csvStream = new (recordChannel);

--- a/io-ballerina/src/io/tests/unit-tests/bytes_io.bal
+++ b/io-ballerina/src/io/tests/unit-tests/bytes_io.bal
@@ -97,7 +97,7 @@ function testFileReadBytes() {
     var result = fileReadBytes(filePath);
     string expectedString = "Sheldon Cooper";
 
-    if (result is byte[]) {
+    if (result is (readonly & byte[])) {
         test:assertEquals(result, expectedString.toBytes(), msg = "Found unexpected output");
     } else {
         test:assertFail(msg = result.message());
@@ -138,10 +138,8 @@ function testFileReadBytesAsStream() {
         } else {
             test:assertFail(msg = returnedString.message());
         }
-    } else if (result is Error) {
-        test:assertFail(msg = result.message());
     } else {
-        test:assertFail("Unknown error occured");
+        test:assertFail(msg = result.message());
     }
 }
 
@@ -222,10 +220,8 @@ function testFileChannelReadBytesAsStream() {
             } else {
                 test:assertFail(msg = returnedString.message());
             }
-        } else if (result is Error) {
-            test:assertFail(msg = result.message());
         } else {
-            test:assertFail("Unknown error occured");
+            test:assertFail(msg = result.message());
         }
     } else {
         test:assertFail(msg = fileOpenResult.message());
@@ -238,8 +234,8 @@ function testFileCopy() {
     string writeFilePath = TEMP_DIR + "ballerina.png";
     var readResult = fileReadBytes(readFilePath);
 
-    if (readResult is byte[]) {
-        var writeResult = fileWriteBytes(writeFilePath, readResult);
+    if (readResult is (readonly & byte[])) {
+        var writeResult = fileWriteBytes(writeFilePath, <@untainted>readResult);
         if (writeResult is Error) {
             test:assertFail(msg = writeResult.message());
         }

--- a/io-ballerina/src/io/tests/unit-tests/char_io.bal
+++ b/io-ballerina/src/io/tests/unit-tests/char_io.bal
@@ -668,10 +668,8 @@ function testFileReadLinesAsStream() {
                                test:assertEquals(val, expectedLines[i]);
                                i += 1;
                            });
-    } else if (result is Error) {
-        test:assertFail(msg = result.message());
     } else {
-        test:assertFail("Unknown error occured");
+        test:assertFail(msg = result.message());
     }
 }
 

--- a/io-ballerina/src/io/tests/unit-tests/csv_io.bal
+++ b/io-ballerina/src/io/tests/unit-tests/csv_io.bal
@@ -682,9 +682,7 @@ function testFileReadCsvAsStream() {
                                }
                                i += 1;
                            });
-    } else if (result is Error) {
-        test:assertFail(msg = result.message());
     } else {
-        test:assertFail("Unknown error occured");
+        test:assertFail(msg = result.message());
     }
 }


### PR DESCRIPTION
## Purpose
Make all return types of the IO APIs consistent with taint checking.

## Approach
- Add tainted return values
- Remove unnecessary null returns

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/31

## Test environment
- macOS
- Java11
- SLP6
