### PR TITLE
Trigger Standard Library dependency update

### DIFF
--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -1,0 +1,23 @@
+name: Dependency update
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - 'build.gradle'
+    - 'gradle.properties'
+
+jobs:
+  trigger-workflow:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - name: Initiating repository event
+        run: |
+          curl -u ${{ secrets.BALLERINA_BOT_USERNAME }} -X POST \
+          https://api.github.com/repos/ballerina-platform/ballerina-standard-library/dispatches \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Authorization: token ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+          --data '{
+            "event_type": "dependency-update"
+          }'

--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -1,4 +1,4 @@
-name: Dependency update
+name: Stdlib Dependency Update
 
 on:
   push:

--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -1,7 +1,6 @@
 name: Dependency update
 
 on:
-  workflow_dispatch:
   push:
     paths:
     - 'build.gradle'


### PR DESCRIPTION
## Purpose
Trigger the `dependency_graph.yml` workflow file in the Standard Library to generate the dependency graph between the Standard Library modules. Workflow is triggered when `build.gradle` file or `gradle.properties` file is updated.
