### PR TITLE
Make channel APIs internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,18 @@ hs_err_pid*
 build
 .gradle/
 target
+
 # IDEA Files
 .idea/
 *.iml
 *.ipr
 *.iws
+
+# VSCode files
+.project
+.classpath
+.settings
+bin/
 
 # MacOS
 *.DS_Store

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -155,8 +155,6 @@ task ballerinaBuild {
             }
 
         }
-//        Disabling doc creation due to this issue(https://github.com/ballerina-platform/ballerina-lang/issues/26733).
-//        Once it fixed, we can enable doc creation.
         // Doc creation and packing
         exec {
             workingDir project.projectDir

--- a/io-ballerina/channel_byte_io.bal
+++ b/io-ballerina/channel_byte_io.bal
@@ -16,12 +16,6 @@
 
 import ballerina/lang.'value;
 
-# Read the entire channel content as a byte array.
-# ```ballerina
-# byte[]|io:Error content = io:channelReadBytes(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible input is a `io:ReadableByteChannel`
-# + return - Either a readonly byte array or `io:Error`
 function channelReadBytes(ReadableChannel readableChannel) returns @tainted readonly & byte[]|Error {
     if (readableChannel is ReadableByteChannel) {
         var result = readableChannel.readAll();
@@ -34,13 +28,6 @@ function channelReadBytes(ReadableChannel readableChannel) returns @tainted read
     }
 }
 
-# Read the entire channel content as a stream of blocks.
-# ```ballerina
-# stream<io:Block>|io:Error content = io:channelReadBlocksAsStream(readableChannel, 1000);
-# ```
-# + readableChannel - A readable channel. The possible input is a `io:ReadableByteChannel`
-# + blockSize - An optional size of the byte block. Default size is 4KB
-# + return - Either a byte block stream or `io:Error`
 function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns @tainted stream<Block>|Error {
     if (readableChannel is ReadableByteChannel) {
         return readableChannel.blockStream(blockSize);
@@ -51,14 +38,6 @@ function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSiz
     }
 }
 
-# Write a given array of bytes to a channel.
-# ```ballerina
-# byte[] content = [60, 78, 39, 28];
-# io:Error? result = io:channelWriteBytes(writableChannel, content);
-# ```
-# + writableChannel - A writable channel. The possible input is a `io:WritableByteChannel`
-# + content - Byte content to write
-# + return - `io:Error` or else `()`
 function channelWriteBytes(WritableChannel writableChannel, byte[] content) returns Error? {
     if (writableChannel is WritableByteChannel) {
         var r = writableChannel.write(content, 0);
@@ -73,15 +52,6 @@ function channelWriteBytes(WritableChannel writableChannel, byte[] content) retu
     }
 }
 
-# Write a byte stream to a channel.
-# ```ballerina
-# byte[] content = [[60, 78, 39, 28]];
-# stream<byte[], io:Error> byteStream = content.toStream();
-# io:Error? result = io:channelWriteBlocksFromStream(writableChannel, byteStream);
-# ```
-# + writableChannel - A writable channel. The possible input is a `io:WritableByteChannel`
-# + byteStream - Byte stream to write
-# + return - `io:Error` or else `()`
 function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[]> byteStream) returns Error? {
     if (writableChannel is WritableByteChannel) {
         error? e = byteStream.forEach(function(byte[] byteContent) {

--- a/io-ballerina/channel_byte_io.bal
+++ b/io-ballerina/channel_byte_io.bal
@@ -22,7 +22,7 @@ import ballerina/lang.'value;
 # ```
 # + readableChannel - A readable channel. The possible input is a `io:ReadableByteChannel`
 # + return - Either a readonly byte array or `io:Error`
-public function channelReadBytes(ReadableChannel readableChannel) returns @tainted readonly & byte[]|Error {
+function channelReadBytes(ReadableChannel readableChannel) returns @tainted readonly & byte[]|Error {
     if (readableChannel is ReadableByteChannel) {
         var result = readableChannel.readAll();
         var closeResult = readableChannel.close();
@@ -41,7 +41,7 @@ public function channelReadBytes(ReadableChannel readableChannel) returns @taint
 # + readableChannel - A readable channel. The possible input is a `io:ReadableByteChannel`
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
-public function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns @tainted stream<Block>|Error {
+function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns @tainted stream<Block>|Error {
     if (readableChannel is ReadableByteChannel) {
         return readableChannel.blockStream(blockSize);
     } else {
@@ -59,7 +59,7 @@ public function channelReadBlocksAsStream(ReadableChannel readableChannel, int b
 # + writableChannel - A writable channel. The possible input is a `io:WritableByteChannel`
 # + content - Byte content to write
 # + return - `io:Error` or else `()`
-public function channelWriteBytes(WritableChannel writableChannel, byte[] content) returns Error? {
+function channelWriteBytes(WritableChannel writableChannel, byte[] content) returns Error? {
     if (writableChannel is WritableByteChannel) {
         var r = writableChannel.write(content, 0);
         var closeResult = writableChannel.close();
@@ -82,7 +82,7 @@ public function channelWriteBytes(WritableChannel writableChannel, byte[] conten
 # + writableChannel - A writable channel. The possible input is a `io:WritableByteChannel`
 # + byteStream - Byte stream to write
 # + return - `io:Error` or else `()`
-public function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[]> byteStream) returns Error? {
+function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[]> byteStream) returns Error? {
     if (writableChannel is WritableByteChannel) {
         error? e = byteStream.forEach(function(byte[] byteContent) {
                                           if (writableChannel is WritableByteChannel) {

--- a/io-ballerina/channel_csv_io.bal
+++ b/io-ballerina/channel_csv_io.bal
@@ -24,7 +24,7 @@ import ballerina/lang.'value;
 # The possible inputs are `io:ReadableByteChannel`, `io:ReadableCharacterChannel` or `io:ReadableCSVChannel`.
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
 # + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
-public function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) returns @tainted string[][]|Error {
+function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) returns @tainted string[][]|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, skipHeaders);
     if (csvChannel is ReadableCSVChannel) {
         string[][] results = [];
@@ -54,7 +54,7 @@ public function channelReadCsv(ReadableChannel readableChannel, int skipHeaders 
 # + readableChannel - A readable channel.
 # The possible inputs are `io:ReadableByteChannel`, `io:ReadableCharacterChannel` or `io:ReadableCSVChannel`.
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
-public function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error {
+function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, 0);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();
@@ -72,7 +72,7 @@ public function channelReadCsvAsStream(ReadableChannel readableChannel) returns 
 # The possible inputs are `io:WritableByteChannel`, `io:WritableCharacterChannel`, or `io:WritableCSVChannel`.
 # + content - CSV content as an array of string arrays
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public function channelWriteCsv(WritableChannel writableChannel, string[][] content) returns Error? {
+function channelWriteCsv(WritableChannel writableChannel, string[][] content) returns Error? {
     var csvChannel = getWritableCSVChannel(writableChannel);
     if (csvChannel is WritableCSVChannel) {
         foreach string[] r in content {
@@ -101,7 +101,7 @@ public function channelWriteCsv(WritableChannel writableChannel, string[][] cont
 # # The possible inputs are `io:WritableByteChannel`, `io:WritableCharacterChannel`, or `io:WritableCSVChannel`.
 # + content - A CSV record stream to be written
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[]> content) returns Error? {
+function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[]> content) returns Error? {
     var csvChannel = getWritableCSVChannel(writableChannel);
     if (csvChannel is WritableCSVChannel) {
         error? e = content.forEach(function(string[] stringContent) {

--- a/io-ballerina/channel_csv_io.bal
+++ b/io-ballerina/channel_csv_io.bal
@@ -16,14 +16,6 @@
 
 import ballerina/lang.'value;
 
-# Read channel content as a CSV.
-# ```ballerina
-# string[][]|io:Error content = io:channelReadCsv(readableChannel);
-# ```
-# + readableChannel - A readable channel.
-# The possible inputs are `io:ReadableByteChannel`, `io:ReadableCharacterChannel` or `io:ReadableCSVChannel`.
-# + skipHeaders - Number of headers, which should be skipped prior to reading records
-# + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
 function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) returns @tainted string[][]|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, skipHeaders);
     if (csvChannel is ReadableCSVChannel) {
@@ -47,13 +39,6 @@ function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) re
     }
 }
 
-# Read channel content as a CSV.
-# ```ballerina
-# stream<string[]>|io:Error content = io:channelReadCsvAsStream(readableChannel);
-# ```
-# + readableChannel - A readable channel.
-# The possible inputs are `io:ReadableByteChannel`, `io:ReadableCharacterChannel` or `io:ReadableCSVChannel`.
-# + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
 function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, 0);
     if (csvChannel is ReadableCSVChannel) {
@@ -63,15 +48,6 @@ function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainte
     }
 }
 
-# Write CSV content to a channel.
-# ```ballerina
-# string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
-# io:Error? result = io:channelWriteCsv(writableChannel, content);
-# ```
-# + writableChannel - A writable channel.
-# The possible inputs are `io:WritableByteChannel`, `io:WritableCharacterChannel`, or `io:WritableCSVChannel`.
-# + content - CSV content as an array of string arrays
-# + return - Either an `io:Error` or the null `()` value when the writing was successful
 function channelWriteCsv(WritableChannel writableChannel, string[][] content) returns Error? {
     var csvChannel = getWritableCSVChannel(writableChannel);
     if (csvChannel is WritableCSVChannel) {
@@ -91,16 +67,6 @@ function channelWriteCsv(WritableChannel writableChannel, string[][] content) re
     }
 }
 
-# Write CSV record stream to a channel.
-# ```ballerina
-# string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
-# stream<string[]> recordStream = content.toStream();
-# io:Error? result = io:channelWriteCsv(writableChannel, recordStream);
-# ```
-# + writableChannel - A writable channel.
-# # The possible inputs are `io:WritableByteChannel`, `io:WritableCharacterChannel`, or `io:WritableCSVChannel`.
-# + content - A CSV record stream to be written
-# + return - Either an `io:Error` or the null `()` value when the writing was successful
 function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[]> content) returns Error? {
     var csvChannel = getWritableCSVChannel(writableChannel);
     if (csvChannel is WritableCSVChannel) {

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -22,7 +22,7 @@ import ballerina/lang.'value;
 # ```
 # + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
 # + return - The entire channel content as a string or an `io:Error`
-public function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
+function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readString();
@@ -39,7 +39,7 @@ public function channelReadString(ReadableChannel readableChannel) returns @tain
 # ```
 # + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
 # + return - The channel content as list of lines or an `io:Error`
-public function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
+function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readAllLines();
@@ -56,7 +56,7 @@ public function channelReadLines(ReadableChannel readableChannel) returns @taint
 # ```
 # + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
 # + return - The channel content as a stream of strings or an `io:Error`
-public function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error {
+function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         return characterChannel.lineStream();
@@ -71,7 +71,7 @@ public function channelReadLinesAsStream(ReadableChannel readableChannel) return
 # ```
 # + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
 # + return - The channel content as a JSON object or an `io:Error`
-public function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
+function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readJson();
@@ -88,7 +88,7 @@ public function channelReadJson(ReadableChannel readableChannel) returns @tainte
 # ```
 # + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
 # + return - The channel content as an XML or an `io:Error`
-public function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
+function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readXml();
@@ -107,7 +107,7 @@ public function channelReadXml(ReadableChannel readableChannel) returns @tainted
 # + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
 # + content - String content to be written
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
+function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         var writeResult = characterChannel.write(content, 0);
@@ -133,7 +133,7 @@ public function channelWriteString(WritableChannel writableChannel, string conte
 # + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
 # + content - An array of string lines to be written
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
+function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         string writeContent = "";
@@ -164,7 +164,7 @@ public function channelWriteLines(WritableChannel writableChannel, string[] cont
 # + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
 # + lineStream - A stream of lines to be written
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string> lineStream) returns Error? {
+function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string> lineStream) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         error? e = lineStream.forEach(function(string stringContent) {
@@ -193,7 +193,7 @@ public function channelWriteLinesFromStream(WritableChannel writableChannel, str
 # + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
 # + content - JSON content to be written
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
+function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         var writeResult = characterChannel.writeJson(content);
@@ -218,7 +218,7 @@ public function channelWriteJson(WritableChannel writableChannel, json content) 
 # + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
 # + content - XML content to be written
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function channelWriteXml(WritableChannel writableChannel, xml content) returns Error? {
+function channelWriteXml(WritableChannel writableChannel, xml content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         var writeResult = characterChannel.writeXml(content);

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -16,12 +16,6 @@
 
 import ballerina/lang.'value;
 
-# Reads the entire channel content as a `string` from the specified channel.
-# ```ballerina
-# string|io:Error content = io:channelReadString(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
-# + return - The entire channel content as a string or an `io:Error`
 function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
@@ -33,12 +27,6 @@ function channelReadString(ReadableChannel readableChannel) returns @tainted str
     }
 }
 
-# Reads the entire channel content as a list of lines from the specified channel.
-# ```ballerina
-# string[]|io:Error content = io:channelReadLines(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
-# + return - The channel content as list of lines or an `io:Error`
 function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
@@ -50,12 +38,6 @@ function channelReadLines(ReadableChannel readableChannel) returns @tainted stri
     }
 }
 
-# Reads channel content as a stream of lines from the specified channel.
-# ```ballerina
-# stream<string>|io:Error content = io:channelReadLinesAsStream(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
-# + return - The channel content as a stream of strings or an `io:Error`
 function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
@@ -65,12 +47,6 @@ function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tain
     }
 }
 
-# Reads channel content as a JSON from the specified channel.
-# ```ballerina
-# json|io:Error content = io:channelReadJson(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
-# + return - The channel content as a JSON object or an `io:Error`
 function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
@@ -82,12 +58,6 @@ function channelReadJson(ReadableChannel readableChannel) returns @tainted json|
     }
 }
 
-# Reads channel content as an XML from the specified channel.
-# ```ballerina
-# xml|io:Error content = io:channelReadXml(readableChannel);
-# ```
-# + readableChannel - A readable channel. The possible inputs are `io:ReadableByteChannel` or `io:ReadableCharacterChannel`.
-# + return - The channel content as an XML or an `io:Error`
 function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
@@ -99,14 +69,6 @@ function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Er
     }
 }
 
-# Writes the given `string` value to the specified channel.
-# ```ballerina
-# string content = "Hello Universe..!!";
-# io:Error result = io:channelWriteString(writableChannel, content);
-# ```
-# + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
-# + content - String content to be written
-# + return - The null `()` value when the writing was successful or an `io:Error`
 function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
@@ -124,15 +86,6 @@ function channelWriteString(WritableChannel writableChannel, string content) ret
     }
 }
 
-# Write the given array of lines to the specified channel.
-# During the writing operation, a newline character `\n` will be added after each line.
-# ```ballerina
-# string[] content = ["Hello Universe..!!", "How are you?"];
-# io:Error result = io:channelWriteLines(writableChannel, content);
-# ```
-# + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
-# + content - An array of string lines to be written
-# + return - The null `()` value when the writing was successful or an `io:Error`
 function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
@@ -154,16 +107,6 @@ function channelWriteLines(WritableChannel writableChannel, string[] content) re
     }
 }
 
-# Write lines from the given stream to the specified channel.
-# During the writing operation, a newline character `\n` will be added after each line.
-# ```ballerina
-# string content = ["Hello Universe..!!", "How are you?"];
-# stream<string, io:Error> lineStream = content.toStream();
-# io:Error result = io:channelWriteLinesFromStream(writableChannel, lineStream);
-# ```
-# + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
-# + lineStream - A stream of lines to be written
-# + return - The null `()` value when the writing was successful or an `io:Error`
 function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string> lineStream) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
@@ -185,14 +128,6 @@ function channelWriteLinesFromStream(WritableChannel writableChannel, stream<str
     }
 }
 
-# Write the given JSON content to the specified channel.
-# ```ballerina
-# json content = {"name": "Anne", "age": 30};
-# io:Error? content = io:channelWriteJson(writableChannel);
-# ```
-# + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
-# + content - JSON content to be written
-# + return - The null `()` value when the writing was successful or an `io:Error`
 function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
@@ -210,14 +145,6 @@ function channelWriteJson(WritableChannel writableChannel, json content) returns
     }
 }
 
-# Write the XML content to the specified channel.
-# ```ballerina
-# xml content = xml `<book>The Lost World</book>`;
-# io:Error? result = io:channelWriteXml(writableChannel, content);
-# ```
-# + writableChannel - A writable channel. The possible inputs are `io:WritableByteChannel` or `io:WritableCharacterChannel`.
-# + content - XML content to be written
-# + return - The null `()` value when the writing was successful or an `io:Error`
 function channelWriteXml(WritableChannel writableChannel, xml content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/404#issuecomment-732729947


## Approach
- Disable public accessibility of channel APIs
- Remove channel API docs

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/31


## Test environment
- SLP6
- Java11
