### PR TITLE
Enable Error? return to block, line, and CSV streams

### DIFF
--- a/io-ballerina/block_stream.bal
+++ b/io-ballerina/block_stream.bal
@@ -37,14 +37,16 @@ public class BlockStream {
     # The next function reads and return the next block of the related stream.
     #
     # + return - Returns a `io:Block` when a block is avaliable in the stream or return null when the stream reaches the end
-    public isolated function next() returns record {| Block value; |}? {
+    public isolated function next() returns record {| Block value; |}|Error? {
         var block = readBlock(self.readableByteChannel, self.blockSize);
         if (block is byte[]) {
             record {| Block value; |} value = {value: <Block>block.cloneReadOnly()};
             return value;
-        } else {
+        } else if (block is EofError){
             var closeResult = closeInputStream(self.readableByteChannel);
             return ();
+        } else {
+            return block;
         }
     }
 

--- a/io-ballerina/channel_byte_io.bal
+++ b/io-ballerina/channel_byte_io.bal
@@ -52,7 +52,7 @@ function channelWriteBytes(WritableChannel writableChannel, byte[] content) retu
     }
 }
 
-function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[]> byteStream) returns Error? {
+function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[], Error?> byteStream) returns Error? {
     if (writableChannel is WritableByteChannel) {
         error? e = byteStream.forEach(function(byte[] byteContent) {
                                           if (writableChannel is WritableByteChannel) {

--- a/io-ballerina/channel_csv_io.bal
+++ b/io-ballerina/channel_csv_io.bal
@@ -39,7 +39,7 @@ function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) re
     }
 }
 
-function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[]>|Error {
+function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[], Error?>|Error {
     var csvChannel = getReadableCSVChannel(readableChannel, 0);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();
@@ -67,7 +67,7 @@ function channelWriteCsv(WritableChannel writableChannel, string[][] content) re
     }
 }
 
-function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[]> content) returns Error? {
+function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[], Error?> content) returns Error? {
     var csvChannel = getWritableCSVChannel(writableChannel);
     if (csvChannel is WritableCSVChannel) {
         error? e = content.forEach(function(string[] stringContent) {

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -38,7 +38,7 @@ function channelReadLines(ReadableChannel readableChannel) returns @tainted stri
     }
 }
 
-function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
+function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error?>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         return characterChannel.lineStream();

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -38,7 +38,7 @@ function channelReadLines(ReadableChannel readableChannel) returns @tainted stri
     }
 }
 
-function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string>|Error {
+function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         return characterChannel.lineStream();
@@ -107,7 +107,7 @@ function channelWriteLines(WritableChannel writableChannel, string[] content) re
     }
 }
 
-function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string> lineStream) returns Error? {
+function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, error?> lineStream) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         error? e = lineStream.forEach(function(string stringContent) {

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -107,7 +107,7 @@ function channelWriteLines(WritableChannel writableChannel, string[] content) re
     }
 }
 
-function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, error?> lineStream) returns Error? {
+function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error?> lineStream) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         error? e = lineStream.forEach(function(string stringContent) {

--- a/io-ballerina/csv_stream.bal
+++ b/io-ballerina/csv_stream.bal
@@ -33,14 +33,16 @@ public class CSVStream {
     #
     # + return - Returns a CSV record as a string array when a record is avaliable in the stream or
     # return null when the stream reaches the end
-    public isolated function next() returns record {| string[] value; |}? {
+    public isolated function next() returns record {| string[] value; |}|Error? {
         var recordValue = readRecord(self.readableTextRecordChannel, COMMA);
         if (recordValue is string[]) {
             record {| string[] value; |} value = {value: <string[]>recordValue.cloneReadOnly()};
             return value;
-        } else {
+        } else if (recordValue is EofError) {
             var closeResult = closeRecordReader(self.readableTextRecordChannel);
             return ();
+        } else {
+            return recordValue;
         }
     }
 

--- a/io-ballerina/file_byte_io.bal
+++ b/io-ballerina/file_byte_io.bal
@@ -31,12 +31,12 @@ public function fileReadBytes(@untainted string path) returns @tainted readonly 
 
 # Read the entire file content as a stream of blocks.
 # ```ballerina
-# stream<io:Block>|io:Error content = io:fileReadBlocksAsStream("./resources/myfile.txt", 1000);
+# stream<io:Block, io:Error?>|io:Error content = io:fileReadBlocksAsStream("./resources/myfile.txt", 1000);
 # ```
 # + path - The path of the file
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
-public function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block>|Error {
+public function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block, Error?>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadBlocksAsStream(byteChannel, blockSize);
@@ -71,7 +71,7 @@ public function fileWriteBytes(@untainted string path, byte[] content) returns E
 # + path - The path of the file
 # + byteStream - Byte stream to write
 # + return - `io:Error` or else `()`
-public function fileWriteBlocksFromStream(@untainted string path, stream<byte[]> byteStream) returns Error? {
+public function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error?> byteStream) returns Error? {
 
     var byteChannel = openWritableFile(path);
     if (byteChannel is WritableByteChannel) {

--- a/io-ballerina/file_csv_io.bal
+++ b/io-ballerina/file_csv_io.bal
@@ -33,11 +33,11 @@ public function fileReadCsv(@untainted string path, int skipHeaders = 0) returns
 
 # Read file content as a CSV.
 # ```ballerina
-# stream<string[]>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
+# stream<string[], io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
-public function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[]>|Error {
+public function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error?>|Error {
     var csvChannel = openReadableCsvFile(path);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();
@@ -66,13 +66,13 @@ public function fileWriteCsv(@untainted string path, string[][] content) returns
 # Write CSV record stream to a file.
 # ```ballerina
 # string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
-# stream<string[]> recordStream = content.toStream();
+# stream<string[], io:Error?> recordStream = content.toStream();
 # io:Error? result = io:fileWriteCsv("./resources/myfile.csv", recordStream);
 # ```
 # + path - The CSV file path
 # + content - A CSV record stream to be written
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public function fileWriteCsvFromStream(@untainted string path, stream<string[]> content) returns Error? {
+public function fileWriteCsvFromStream(@untainted string path, stream<string[], Error?> content) returns Error? {
     var csvChannel = openWritableCsvFile(path);
     if (csvChannel is WritableCSVChannel) {
         return channelWriteCsvFromStream(csvChannel, content);

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -46,11 +46,11 @@ public function fileReadLines(@untainted string path) returns @tainted string[]|
 
 # Reads file content as a stream of lines.
 # ```ballerina
-# stream<string>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
+# stream<string, io:Error?>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
 # ```
 # + path - The path of the file
 # + return - The file content as a stream of strings or an `io:Error`
-public function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string>|Error {
+public function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error?>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadLinesAsStream(byteChannel);
@@ -128,13 +128,13 @@ public function fileWriteLines(@untainted string path, string[] content) returns
 # During the writing operation, a newline character `\n` will be added after each line.
 # ```ballerina
 # string content = ["Hello Universe..!!", "How are you?"];
-# stream<string, io:Error> lineStream = content.toStream();
+# stream<string, io:Error?> lineStream = content.toStream();
 # io:Error result = io:fileWriteLinesFromStream("./resources/myfile.txt", lineStream);
 # ```
 # + path - The path of the file
 # + lineStream -  A stream of lines to write
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteLinesFromStream(@untainted string path, stream<string> lineStream) returns Error? {
+public function fileWriteLinesFromStream(@untainted string path, stream<string, Error?> lineStream) returns Error? {
     var byteChannel = openWritableFile(path);
     if (byteChannel is WritableByteChannel) {
         return channelWriteLinesFromStream(byteChannel, lineStream);

--- a/io-ballerina/line_stream.bal
+++ b/io-ballerina/line_stream.bal
@@ -32,14 +32,16 @@ public class LineStream {
     # The next function reads and return the next line of the related stream.
     #
     # + return - Returns a line as a string when a line is avaliable in the stream or return null when the stream reaches the end
-    public isolated function next() returns record {| string value; |}? {
+    public isolated function next() returns record {| string value; |}|Error? {
         var line = readLine(self.readableCharacterChannel);
         if (line is string) {
             record {| string value; |} value = {value: <string>line.cloneReadOnly()};
             return value;
-        } else {
+        } else if (line is EofError) {
             var closeResult = closeReader(self.readableCharacterChannel);
             return ();
+        } else {
+            return line;
         }
     }
 

--- a/io-ballerina/readable_byte_channel.bal
+++ b/io-ballerina/readable_byte_channel.bal
@@ -57,13 +57,13 @@ public class ReadableByteChannel {
 
     # Return a block stream that can be used to read all `byte` blocks as a stream.
     # ```ballerina
-    # stream<io:Block>|io:Error result = readableByteChannel.blockStream();
+    # stream<io:Block, io:Error?>|io:Error result = readableByteChannel.blockStream();
     # ```
     # + blockSize - A positive integer. Size of the block.
     # + return - Either a block stream or else an `io:Error`
-    public function blockStream(int blockSize) returns @tainted stream<Block>|Error {
+    public function blockStream(int blockSize) returns @tainted stream<Block, Error?>|Error {
         BlockStream blockStream = new (self, blockSize);
-        return new stream<Block>(blockStream);
+        return new stream<Block, Error?>(blockStream);
     }
 
     # Encodes a given `ReadableByteChannel` using the Base64 encoding scheme.

--- a/io-ballerina/readable_character_channel.bal
+++ b/io-ballerina/readable_character_channel.bal
@@ -95,13 +95,13 @@ public class ReadableCharacterChannel {
 
     # Return a stream of lines that can be used to read all the lines in a file as a stream.
     # ```ballerina
-    # stream<string>|io:Error? result = readableCharChannel.lineStream();
+    # stream<string, io:Error?>|io:Error? result = readableCharChannel.lineStream();
     # ```
     #
     # + return - Either a stream of strings(lines) or an io:Error.
-    public function lineStream() returns stream<string>|Error {
+    public function lineStream() returns stream<string, Error?>|Error {
         LineStream lineStream = new (self);
-        return new stream<string>(lineStream);
+        return new stream<string, Error?>(lineStream);
     }
 
     # Reads all properties from a .properties file.

--- a/io-ballerina/readable_csv_channel.bal
+++ b/io-ballerina/readable_csv_channel.bal
@@ -84,15 +84,15 @@ public class ReadableCSVChannel {
 
     # Returns a CSV record stream that can be used to CSV records as a stream.
     # ```ballerina
-    # string[]|io:Error? record = readableCSVChannel.csvStream();
+    # stream<string[], io:Error?>|io:Error? record = readableCSVChannel.csvStream();
     # ```
     #
     # + return - Either a stream of records(string[]) or else an `io:Error`
-    public function csvStream() returns stream<string[]>|Error {
+    public function csvStream() returns stream<string[], Error?>|Error {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
             CSVStream csvStream = new (recordChannel);
-            return new stream<string[]>(csvStream);
+            return new stream<string[], Error?>(csvStream);
         } else {
             GenericError e = error GenericError("channel not initialized");
             panic e;

--- a/io-ballerina/tests/bytes_io.bal
+++ b/io-ballerina/tests/bytes_io.bal
@@ -208,8 +208,8 @@ function testFileChannelReadBytesAsStream() {
     var fileOpenResult = openReadableFile(filePath);
     if (fileOpenResult is ReadableByteChannel) {
         var result = channelReadBlocksAsStream(fileOpenResult, 2);
-        if (result is stream<Block>) {
-            _ = result.forEach(function(Block val) {
+        if (result is stream<Block, Error?>) {
+            error? e = result.forEach(function(Block val) {
                                    foreach byte b in val {
                                        byteArr.push(b);
                                    }

--- a/io-ballerina/tests/char_io.bal
+++ b/io-ballerina/tests/char_io.bal
@@ -662,12 +662,17 @@ function testFileReadLinesAsStream() {
     string filePath = TEMP_DIR + "stringContentAsLines2.txt";
     string[] expectedLines = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
     var result = fileReadLinesAsStream(filePath);
-    if (result is stream<string>) {
+    if (result is stream<string, error?>) {
         int i = 0;
-        _ = result.forEach(function(string val) {
+        error? e = result.forEach(function(string val) {
                                test:assertEquals(val, expectedLines[i]);
                                i += 1;
                            });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 4);
     } else {
         test:assertFail(msg = result.message());
     }

--- a/io-ballerina/tests/csv_io.bal
+++ b/io-ballerina/tests/csv_io.bal
@@ -672,9 +672,9 @@ function testFileReadCsvAsStream() {
     "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", 
     "30 years", "Colombo"]];
     var result = fileReadCsvAsStream(filePath);
-    if (result is stream<string[]>) {
+    if (result is stream<string[], Error?>) {
         int i = 0;
-        _ = result.forEach(function(string[] val) {
+        error? e = result.forEach(function(string[] val) {
                                int j = 0;
                                foreach string s in val {
                                    test:assertEquals(s, expectedContent[i][j]);
@@ -682,6 +682,10 @@ function testFileReadCsvAsStream() {
                                }
                                i += 1;
                            });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 3);
     } else {
         test:assertFail(msg = result.message());
     }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/853

## Approach
Add `io:Error?` to each of the following I/O streams:
- block stream
- line stream
- CSV stream

## Automation tests
 - Unit tests 
   > Yes

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/31


## Test environment
- SLP9
- Java 11
- macOS