### PR TITLE
Enable TRUNCATE_EXISTING for writing operations

### DIFF
--- a/io-ballerina/tests/bytes_io.bal
+++ b/io-ballerina/tests/bytes_io.bal
@@ -244,6 +244,39 @@ function testFileCopy() {
     }
 }
 
+@test:Config {}
+function testFileWriteBytesWithTruncate() {
+    string filePath = TEMP_DIR + "bytesFile6.txt";
+    createDirectoryExtern(TEMP_DIR);
+    string content1 = "Ballerina is an open source programming language and " +
+    "platform for cloud-era application programmers to easily write software that just works.";
+    string content2 = "Ann Johnson is a banker.";
+
+    // Check content 01
+    var result1 = fileWriteBytes(filePath, content1.toBytes());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadBytes(filePath);
+    if (result2 is (readonly & byte[])) {
+        test:assertEquals(result2, content1.toBytes());
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteBytes(filePath, content2.toBytes());
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadBytes(filePath);
+    if (result4 is (readonly & byte[])) {
+        test:assertEquals(result4, content2.toBytes());
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
 function createDirectoryExtern(string path) = @java:Method {
     name: "createDirectory",
     'class: "org.ballerinalang.stdlib.io.testutils.FileTestUtils"

--- a/io-ballerina/tests/char_io.bal
+++ b/io-ballerina/tests/char_io.bal
@@ -291,6 +291,44 @@ function testFileReadJson() {
 }
 
 @test:Config {}
+function testFileWriteJsonWithTruncate() {
+    string filePath = TEMP_DIR + "jsonCharsFile3.json";
+    json content1 = {"web-app": {"servlet-mapping": {
+                "cofaxCDS": "/",
+                "cofaxEmail": "/cofaxutil/aemail/*",
+                "cofaxAdmin": "/admin/*",
+                "fileServlet": "/static/*",
+                "cofaxTools": ["/tools1/*", "/tools2/*", "/tools3/*"]
+            }}};
+    json content2 = {"userName": "Harry Thompson", "age": 23};
+
+    // Check content 01
+    var result1 = fileWriteJson(filePath, content1);
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadJson(filePath);
+    if (result2 is json) {
+        test:assertEquals(result2, content1);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteJson(filePath, content2);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4= fileReadJson(filePath);
+    if (result4 is json) {
+        test:assertEquals(result4, content2);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+
+@test:Config {}
 function testWriteHigherUnicodeJson() {
     string filePath = TEMP_DIR + "higherUniJsonCharsFile.json";
     createDirectoryExtern(TEMP_DIR);
@@ -505,6 +543,61 @@ function testFileReadXml() {
 }
 
 @test:Config {}
+function testFileWriteXmlWithTruncate() {
+    string filePath = TEMP_DIR + "xmlCharsFile3.xml";
+    xml content1 = xml `<CATALOG>
+                       <CD>
+                           <TITLE>Empire Burlesque</TITLE>
+                           <ARTIST>Bob Dylan</ARTIST>
+                           <COUNTRY>USA</COUNTRY>
+                           <COMPANY>Columbia</COMPANY>
+                           <PRICE>10.90</PRICE>
+                           <YEAR>1985</YEAR>
+                       </CD>
+                       <CD>
+                           <TITLE>Hide your heart</TITLE>
+                           <ARTIST>Bonnie Tyler</ARTIST>
+                           <COUNTRY>UK</COUNTRY>
+                           <COMPANY>CBS Records</COMPANY>
+                           <PRICE>9.90</PRICE>
+                           <YEAR>1988</YEAR>
+                       </CD>
+                       <CD>
+                           <TITLE>Greatest Hits</TITLE>
+                           <ARTIST>Dolly Parton</ARTIST>
+                           <COUNTRY>USA</COUNTRY>
+                           <COMPANY>RCA</COMPANY>
+                           <PRICE>9.90</PRICE>
+                           <YEAR>1982</YEAR>
+                       </CD>
+                   </CATALOG>`;
+    xml content2 = xml `<USER><NAME>Mary Jane</NAME><AGE>33</AGE></USER>`;
+    // Check content 01
+    var result1 = fileWriteXml(filePath, content1);
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadXml(filePath);
+    if (result2 is xml) {
+        test:assertEquals(result2, content1);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteXml(filePath, content2);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadXml(filePath);
+    if (result4 is xml) {
+        test:assertEquals(result4, content2);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
 function testReadAvailableProperty() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/person.properties";
     string expectedProperty = "John Smith";
@@ -622,6 +715,38 @@ function testFileReadString() {
 }
 
 @test:Config {}
+function testFileWriteStringWithTruncate() {
+    string filePath = TEMP_DIR + "stringContent2.txt";
+    string content1 = "Ballerina is an open source programming language and " +
+    "platform for cloud-era application programmers to easily write software that just works.";
+    string content2 = "Ann Johnson is a banker.";
+
+    // Check content 01
+    var result1 = fileWriteString(filePath, content1);
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadString(filePath);
+    if (result2 is string) {
+        test:assertEquals(result2, content1);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check overridden content 02
+    var result3 = fileWriteString(filePath, content2);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadString(filePath);
+    if (result4 is string) {
+        test:assertEquals(result4, content2);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
 function testFileWriteLines() {
     string filePath = TEMP_DIR + "stringContentAsLines1.txt";
     string[] content = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
@@ -680,7 +805,7 @@ function testFileReadLinesAsStream() {
 
 @test:Config {}
 function testFileChannelWriteStringWithByteChannel() {
-    string filePath = TEMP_DIR + "stringContent2.txt";
+    string filePath = TEMP_DIR + "stringContent3.txt";
     string content = "The Big Bang Theory";
 
     var fileOpenResult = openWritableFile(filePath);
@@ -696,7 +821,7 @@ function testFileChannelWriteStringWithByteChannel() {
 
 @test:Config {dependsOn: [testFileChannelWriteStringWithByteChannel]}
 function testFileChannelReadStringWithByteChannel() {
-    string filePath = TEMP_DIR + "stringContent2.txt";
+    string filePath = TEMP_DIR + "stringContent3.txt";
     string expectedString = "The Big Bang Theory";
 
     var fileOpenResult = openReadableFile(filePath);
@@ -714,7 +839,7 @@ function testFileChannelReadStringWithByteChannel() {
 
 @test:Config {}
 function testFileChannelWriteLinesWithByteChannel() {
-    string filePath = TEMP_DIR + "stringContent2.txt";
+    string filePath = TEMP_DIR + "stringContent3.txt";
     string content = "The Big Bang Theory";
 
     var fileOpenResult = openWritableFile(filePath);
@@ -730,7 +855,7 @@ function testFileChannelWriteLinesWithByteChannel() {
 
 @test:Config {dependsOn: [testFileChannelWriteLinesWithByteChannel]}
 function testFileChannelReadLinesWithByteChannel() {
-    string filePath = TEMP_DIR + "stringContent2.txt";
+    string filePath = TEMP_DIR + "stringContent3.txt";
     string expectedString = "The Big Bang Theory";
 
     var fileOpenResult = openReadableFile(filePath);

--- a/io-ballerina/tests/csv_io.bal
+++ b/io-ballerina/tests/csv_io.bal
@@ -690,3 +690,54 @@ function testFileReadCsvAsStream() {
         test:assertFail(msg = result.message());
     }
 }
+
+@test:Config {}
+function testFileCsvWriteWithTruncate() {
+    string filePath = TEMP_DIR + "workers2.csv";
+    string[][] content1 = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
+    "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
+    "Colombo"]];
+    string[][] content2 = [["Distributed Computing", "A001", "Prof. Jack"], ["Quantum Computing", "A002", "Dr. Sam"],
+    ["Artificail Intelligence", "A003", "Prof. Angelina"]];
+
+    // Check content 01
+    var result1 = fileWriteCsv(filePath, content1);
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadCsv(filePath);
+    if (result2 is string[][]) {
+        int i = 0;
+        foreach string[] r in content1 {
+            int j = 0;
+            foreach string s in r {
+                test:assertEquals(s, content1[i][j]);
+                j += 1;
+            }
+            i += 1;
+        }
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteCsv(filePath, content2);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadCsv(filePath);
+    if (result4 is string[][]) {
+        int i = 0;
+        foreach string[] r in content2 {
+            int j = 0;
+            foreach string s in r {
+                test:assertEquals(s, content2[i][j]);
+                j += 1;
+            }
+            i += 1;
+        }
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+
+}

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOUtils.java
@@ -250,6 +250,7 @@ public class IOUtils {
                     opts.add(StandardOpenOption.APPEND);
                 } else {
                     opts.add(StandardOpenOption.WRITE);
+                    opts.add(StandardOpenOption.TRUNCATE_EXISTING);
                 }
             }
             return FileChannel.open(path, opts);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/878

## Approach
Enable `StandardOpenOption.TRUNCATE_EXISTING` option for writing operations.

## Automation tests
 - Unit tests 
   > Yes

## Test environment
- macOS
- Java11
- SLAlpha1