### PR TITLE
Avoid creating full length byte array

### DIFF
--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/ByteChannelUtils.java
@@ -47,8 +47,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.ballerinalang.stdlib.io.utils.IOConstants.BYTE_CHANNEL_NAME;
 
@@ -108,10 +106,7 @@ public class ByteChannelUtils extends AbstractNativeChannel {
                         return IOUtils.createEoFError();
                     }
                     output.write(buffer, 0, n);
-                    byte[] bytes = output.toByteArray();
-                    Map<String, Object> map = new HashMap<>();
-                    map.put(STREAM_BLOCK_ENTRY, ValueCreator.createArrayValue(bytes));
-                    return ValueCreator.createArrayValue(buffer);
+                    return ValueCreator.createArrayValue(output.toByteArray());
                 }
             }
             return IOUtils.createError("BufferedInputStream is not initialized");


### PR DESCRIPTION
## Purpose
> $subject. With this fix, content is written to the  `ByteArrayOutputStream` up to the content length and convert the stream to an array. So can get rid of creating arrays which equal to the user given input(8196)

## Usecase

```ballerina
@test:Config {}
public function testSetByteStreamFromChannelAndGetByteStream() {
    string content = "Hello Ballerina!";
    string fileLocation = checkpanic createTemporaryFile("testFile", ".tmp", content);
    io:ReadableByteChannel byteChannel = checkpanic io:openReadableFile(fileLocation);
    stream<io:Block, io:Error> blockStream = checkpanic byteChannel.blockStream(8196);
    Entity entity = new;
    entity.setByteStream(blockStream);

    var str = entity.getByteStream();
    if (str is stream<byte[], io:Error>) {
        record {|byte[] value;|}|io:Error? arr1 = str.next();
        if (arr1 is record {|byte[] value;|}) {
            string name = checkpanic strings:fromBytes(arr1.value);
            test:assertEquals(name, content, msg = "Found unexpected output");
        } else {
            test:assertFail(msg = "Found unexpected arr1 output type");
        }
    } else {
       test:assertFail(msg = "Found unexpected str output type" + str.message());
    }
}
```
Output
```
                        --- expected
                        +++ actual
                        
                        @@ -1,1 +1,103 @@
                        
                        -Hello Ballerina!
                        +Hello Ballerina!
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        +
                        

```
