### PR TITLE
Publish Code Coverage Exec Files and Enable publishing testable jars

### DIFF
--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 }
 
 clean {
-    delete "$project.projectDir/target"
+    delete "${project.projectDir}/target"
 }
 
 jar {
@@ -49,13 +49,13 @@ task unpackJballerinaTools(type: Copy) {
 
 def packageName = "io"
 def packageOrg = "ballerina"
- def tomlVersion = project.version.split("-")[0]
-def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
-def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
-def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
-def artifactLibParent = file("$project.projectDir/build/lib_parent/")
-def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
-def artifactTestableJar = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
+def tomlVersion = project.version.split("-")[0]
+def ballerinaConfigFile = new File("${project.projectDir}/Ballerina.toml")
+def artifactBallerinaDocs = file("${project.projectDir}/build/docs_parent/")
+def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
+def artifactLibParent = file("${project.projectDir}/build/lib_parent/")
+def artifactCodeCoverageReport = file("${project.projectDir}/target/cache/tests_cache/coverage/ballerina.exec")
+def artifactTestableJar = file("${project.projectDir}/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 def originalConfig = ballerinaConfigFile.text
@@ -102,9 +102,9 @@ task ballerinaTest {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
             }
         }
     }
@@ -129,20 +129,20 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build $testParams ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build $testParams ${debugParams}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build ${testParams} ${debugParams}"
             }
         }
         copy {
-            from file("$project.projectDir/target/bala")
-            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("${project.projectDir}/target/bala")
+            into file("${artifactCacheParent}/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
         copy {
-            from file("$project.projectDir/target/cache")
+            from file("${project.projectDir}/target/cache")
             exclude '**/*-testable.jar'
             exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
+            into file("${artifactCacheParent}/cache/")
         }
 
         // Publish to central
@@ -152,9 +152,9 @@ task ballerinaBuild {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                    commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat push && exit %%ERRORLEVEL%%"
                 } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                    commandLine 'sh', '-c', "${distributionBinPath}/bal push"
                 }
             }
 
@@ -164,14 +164,14 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat doc && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                commandLine 'sh', '-c', "${distributionBinPath}/bal doc"
             }
         }
         copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            from file("${project.projectDir}/target/apidocs/${packageName}")
+            into file("${project.projectDir}/build/docs_parent/docs/${packageName}")
         }
         ballerinaConfigFile.text = originalConfig
     }
@@ -182,7 +182,7 @@ task ballerinaBuild {
 }
 
 task createArtifactZip(type: Zip) {
-    destinationDirectory = file("$buildDir/distributions")
+    destinationDirectory = file("${buildDir}/distributions")
     from ballerinaBuild
 }
 

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -98,13 +98,6 @@ task initializeVariables {
 }
 
 task ballerinaTest {
-    dependsOn(":io-native:build")
-    dependsOn(":io-native:test")
-    dependsOn(":io-test-utils:build")
-    dependsOn(unpackJballerinaTools)
-    dependsOn(updateTomlFile)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
 
     doLast {
         exec {
@@ -119,24 +112,15 @@ task ballerinaTest {
     }
 }
 
-test {
-    dependsOn(ballerinaTest)
-}
-
 task ballerinaBuild {
     inputs.dir file(project.projectDir)
-    dependsOn(initializeVariables)
-    dependsOn(updateTomlFile)
-    dependsOn(test)
-    dependsOn(unpackJballerinaTools)
-    finalizedBy(revertTomlFile)
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(':io-ballerina:build') || graph.hasTask(':io-ballerina:publish')) {
+        if (graph.hasTask(':io-ballerina:build')) {
             ballerinaTest.enabled = false
         }
-        if (graph.hasTask(':io-ballerina:test')) {
+        if (graph.hasTask(':io-ballerin:test')) {
             testParams = "--code-coverage --includes=*"
         }
     }
@@ -147,9 +131,9 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build $testParams ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build ${testParams} ${debugParams}"
+                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build $testParams ${debugParams}"
             }
         }
         copy {
@@ -228,6 +212,19 @@ publishing {
     }
 }
 
-build {
-    dependsOn(ballerinaBuild)
-}
+ballerinaTest.dependsOn ":io-native:build"
+ballerinaTest.dependsOn ":io-native:test"
+ballerinaTest.dependsOn ":io-test-utils:build"
+ballerinaTest.dependsOn unpackJballerinaTools
+ballerinaTest.dependsOn updateTomlFile
+ballerinaTest.dependsOn initializeVariables
+ballerinaTest.finalizedBy revertTomlFile
+test.dependsOn ballerinaTest
+
+ballerinaBuild.dependsOn test
+ballerinaBuild.dependsOn unpackJballerinaTools
+ballerinaBuild.dependsOn initializeVariables
+ballerinaBuild.dependsOn updateTomlFile
+ballerinaBuild.finalizedBy revertTomlFile
+build.dependsOn ballerinaBuild
+

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -225,6 +225,9 @@ ballerinaTest.finalizedBy revertTomlFile
 test.dependsOn ballerinaTest
 
 ballerinaBuild.dependsOn test
+ballerinaBuild.dependsOn ":io-native:build"
+ballerinaBuild.dependsOn ":io-native:test"
+ballerinaBuild.dependsOn ":io-test-utils:build"
 ballerinaBuild.dependsOn unpackJballerinaTools
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn updateTomlFile

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -49,12 +49,13 @@ task unpackJballerinaTools(type: Copy) {
 
 def packageName = "io"
 def packageOrg = "ballerina"
+ def tomlVersion = project.version.split("-")[0]
 def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
 def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
 def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
 def artifactLibParent = file("$project.projectDir/build/lib_parent/")
 def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
-def tomlVersion = project.version.split("-")[0]
+def artifactTestableJar = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 def originalConfig = ballerinaConfigFile.text
@@ -83,15 +84,12 @@ task initializeVariables {
     if (project.hasProperty("groups")) {
         groupParams = "--groups ${project.findProperty("groups")}"
     }
-
     if (project.hasProperty("disable")) {
         disableGroups = "--disable-groups ${project.findProperty("disable")}"
     }
-
     if (project.hasProperty("debug")) {
         debugParams = "--debug ${project.findProperty("debug")}"
     }
-
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
     }
@@ -117,10 +115,10 @@ task ballerinaBuild {
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(':io-ballerina:build')) {
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish")) {
             ballerinaTest.enabled = false
         }
-        if (graph.hasTask(':io-ballerin:test')) {
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
             testParams = "--code-coverage --includes=*"
         }
     }
@@ -188,8 +186,12 @@ task createArtifactZip(type: Zip) {
     from ballerinaBuild
 }
 
-def getCheckedOutGitCommitHash() {
-    'git rev-parse --verify --short HEAD'.execute().text.trim()
+task createTestableJarZip(type: Zip) {
+    archiveName("${packageOrg}-${packageName}-${project.version}-testable-jars.zip")
+    destinationDir(file("${buildDir}/distributions"))
+    from ("${artifactTestableJar}") {
+        include '**/*-testable.jar'
+    }
 }
 
 publishing {
@@ -197,6 +199,7 @@ publishing {
         maven(MavenPublication) {
             artifact source: createArtifactZip, extension: 'zip'
             artifact source: artifactCodeCoverageReport, classifier: 'jacoco'
+            artifact source: createTestableJarZip, classifier: 'testable-jars', extension: 'zip'
         }
     }
 
@@ -228,3 +231,4 @@ ballerinaBuild.dependsOn updateTomlFile
 ballerinaBuild.finalizedBy revertTomlFile
 build.dependsOn ballerinaBuild
 
+createTestableJarZip.dependsOn ballerinaBuild


### PR DESCRIPTION
## Purpose
> Publish `exec` file generate by the testerina as a Maven artifact and enable to publish testable jar files. With this PR exec file will be named as `io-ballerina-<version>-jacoco.exec` and testable jars will be named as `io-ballerina-<version>-testable-jars`
