### PR TITLE
Introduce XML writing operations for DOCTYPE declaration writing

### DIFF
--- a/io-ballerina/constants.bal
+++ b/io-ballerina/constants.bal
@@ -54,5 +54,11 @@ public const COLON = ":";
 # New line character.
 public const NEW_LINE = "\n";
 
+# Single space character
+const SINGLE_SPACE = " ";
+
+# Double quote character
+const DOUBLE_QUOTE = "\"";
+
 # Default encoding for the abstract read/write APIs.
 public const DEFAULT_ENCODING = "UTF8";

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -181,10 +181,10 @@ public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptio
     xml writeContent = xml ``;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {
         if (fileWriteOption == APPEND) {
-            return error ConfigurationError("The APPEND operation not allowed with DOCUMENT");
+            return error ConfigurationError("The file append operation is not allowed for Document Entity");
         }
         if (xml:length(content) > 1) {
-            return error ConfigurationError("The DOCUMENT XML can only contains single root");
+            return error ConfigurationError("The XML Document can only contains single root");
         }
         if (xmlOptions.doctype != ()) {
             writeContent = xml:concat(populateDoctype(content, <XmlDoctype>xmlOptions.doctype), NEW_LINE, content);

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -98,8 +98,8 @@ public function fileReadXml(@untainted string path) returns @tainted xml|Error {
 # + content - String content to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteString(@untainted string path, string content,
-                    FileWriteOption option = OVERWRITE) returns Error? {
+public function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns
+Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
         return channelWriteString(byteChannel, content);
@@ -118,8 +118,8 @@ public function fileWriteString(@untainted string path, string content,
 # + content - An array of string lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteLines(@untainted string path, string[] content,
-                    FileWriteOption option = OVERWRITE) returns Error? {
+public function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns
+Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
         return channelWriteLines(byteChannel, content);
@@ -139,8 +139,8 @@ public function fileWriteLines(@untainted string path, string[] content,
 # + lineStream -  A stream of lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream,
-                    FileWriteOption option = OVERWRITE) returns Error? {
+public function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, FileWriteOption option =
+                                         OVERWRITE) returns Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
         return channelWriteLinesFromStream(byteChannel, lineStream);
@@ -176,7 +176,8 @@ public function fileWriteJson(@untainted string path, json content) returns @tai
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
 # + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption = OVERWRITE) returns Error? {
+public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption =
+                             OVERWRITE) returns Error? {
     WritableByteChannel|Error byteChannel;
     xml writeContent = xml ``;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {
@@ -211,28 +212,24 @@ public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptio
 function populateDoctype(xml content, XmlDoctype doctype) returns string {
     // Generate <!DOCTYPE rootElementName PUBLIC|SYSTEM PublicIdentifier SystemIdentifier internalSubset>
     string doctypeElement = "";
-    string startElement = "<!DOCTYPE ";
+    string startElement = "<!DOCTYPE";
     string endElement = ">";
     string systemElement = "SYSTEM";
     string publicElement = "PUBLIC";
-    xml:Element rootElement = <xml:Element> content;
+    xml:Element rootElement = <xml:Element>content;
     if (doctype.internalSubset != ()) {
-         doctypeElement = startElement + <string>rootElement.getName() +
-                            SINGLE_SPACE + <string>doctype.internalSubset + endElement;
+        doctypeElement = string `${startElement} ${<string>rootElement.getName()} ${<string>doctype.internalSubset}${
+        endElement}`;
     } else if (doctype.'public != () && doctype.system != ()) {
-         doctypeElement = startElement + <string>rootElement.getName() +
-                            SINGLE_SPACE + publicElement + SINGLE_SPACE +
-                            DOUBLE_QUOTE + <string>doctype.'public + DOUBLE_QUOTE + SINGLE_SPACE +
-                            DOUBLE_QUOTE + <string>doctype.system + DOUBLE_QUOTE + endElement;
+        doctypeElement = string `${startElement} ${<string>rootElement.getName()} ${publicElement} "${<string>doctype.
+        'public}" "${<string>doctype.system}"${endElement}`;
 
     } else if (doctype.'public != ()) {
-         doctypeElement = startElement + <string>rootElement.getName() +
-                            SINGLE_SPACE + publicElement + SINGLE_SPACE +
-                            DOUBLE_QUOTE + <string>doctype.'public + DOUBLE_QUOTE + endElement;
+        doctypeElement = string `${startElement} ${<string>rootElement.getName()} ${publicElement} "${<string>doctype.
+        'public}"${endElement}`;
     } else if (doctype.system != ()) {
-         doctypeElement = startElement + <string>rootElement.getName() +
-                            SINGLE_SPACE + systemElement + SINGLE_SPACE +
-                            DOUBLE_QUOTE + <string>doctype.system + DOUBLE_QUOTE + endElement;
+        doctypeElement = string `${startElement} ${<string>rootElement.getName()} ${systemElement} "${<string>doctype.
+        system}"${endElement}`;
     }
     return doctypeElement;
 }

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -173,10 +173,10 @@ public function fileWriteJson(@untainted string path, json content) returns @tai
 # ```
 # + path - The path of the XML file
 # + content - XML content to write
-# + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
+# + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteXml(@untainted string path, xml content, FileWriteOption fileWriteOption = OVERWRITE, *XmlWriteOptions xmlOptions) returns Error? {
+public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption=OVERWRITE) returns Error? {
     WritableByteChannel|Error byteChannel;
     xml writeContent = xml ``;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -176,7 +176,7 @@ public function fileWriteJson(@untainted string path, json content) returns @tai
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
 # + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption=OVERWRITE) returns Error? {
+public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption = OVERWRITE) returns Error? {
     WritableByteChannel|Error byteChannel;
     xml writeContent = xml ``;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {

--- a/io-ballerina/io_error.bal
+++ b/io-ballerina/io_error.bal
@@ -32,5 +32,7 @@ public type TypeMismatchError distinct error;
 # This will get returned if read operations are performed on a channel after it closed.
 public type EofError distinct error;
 
+public type ConfigurationError distinct error;
+
 # Represents IO module related errors.
-public type Error GenericError|ConnectionTimedOutError|AccessDeniedError|FileNotFoundError|TypeMismatchError|EofError;
+public type Error GenericError|ConnectionTimedOutError|AccessDeniedError|FileNotFoundError|TypeMismatchError|EofError|ConfigurationError;

--- a/io-ballerina/open.bal
+++ b/io-ballerina/open.bal
@@ -25,6 +25,26 @@ public enum FileWriteOption {
     APPEND
 }
 
+# Represents the XML content type that need to be written.
+#
+# + DOCUMENT - An XML document with a single root node
+# + EXTERNAL_PARSED_ENTITY - Externally parsed well-formed XML entity
+public enum XmlContentType {
+    DOCUMENT,
+    EXTERNAL_PARSED_ENTITY
+}
+
+# The writing options of an XML.
+#
+# + xmlContentType - Content type of the XML input(default value is `DOCUMENT`)
+# + docType - XML DOCTYPE value(default value is null)
+# + fileWriteOption - file writing option(default value is `OVERWRITE`)
+public type XmlWriteOptions record {|
+    XmlContentType xmlContentType = DOCUMENT;
+    string? docType = ();
+    FileWriteOption fileWriteOption = OVERWRITE;
+|};
+
 public function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
     name: "openReadableFile",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"

--- a/io-ballerina/open.bal
+++ b/io-ballerina/open.bal
@@ -16,35 +16,6 @@
 
 import ballerina/jballerina.java;
 
-# Represents a file opening options for writing.
-#
-# + OVERWRITE - Overriwrite(truncate the existing content)
-# + APPEND - Append to the existing content
-public enum FileWriteOption {
-    OVERWRITE,
-    APPEND
-}
-
-# Represents the XML content type that need to be written.
-#
-# + DOCUMENT - An XML document with a single root node
-# + EXTERNAL_PARSED_ENTITY - Externally parsed well-formed XML entity
-public enum XmlContentType {
-    DOCUMENT,
-    EXTERNAL_PARSED_ENTITY
-}
-
-# The writing options of an XML.
-#
-# + xmlContentType - Content type of the XML input(default value is `DOCUMENT`)
-# + docType - XML DOCTYPE value(default value is null)
-# + fileWriteOption - file writing option(default value is `OVERWRITE`)
-public type XmlWriteOptions record {|
-    XmlContentType xmlContentType = DOCUMENT;
-    string? docType = ();
-    FileWriteOption fileWriteOption = OVERWRITE;
-|};
-
 public function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
     name: "openReadableFile",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"

--- a/io-ballerina/options.bal
+++ b/io-ballerina/options.bal
@@ -16,7 +16,7 @@
 
 # Represents a file opening options for writing.
 #
-# + OVERWRITE - Overriwrite(truncate the existing content)
+# + OVERWRITE - Overwrite(truncate the existing content)
 # + APPEND - Append to the existing content
 public enum FileWriteOption {
     OVERWRITE,

--- a/io-ballerina/options.bal
+++ b/io-ballerina/options.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents a file opening options for writing.
+#
+# + OVERWRITE - Overriwrite(truncate the existing content)
+# + APPEND - Append to the existing content
+public enum FileWriteOption {
+    OVERWRITE,
+    APPEND
+}
+
+# Represents the XML entity type that needs to be written.
+#
+# + DOCUMENT_ENTITY - An XML document with a single root node
+# + EXTERNAL_PARSED_ENTITY - Externally parsed well-formed XML entity
+public enum XmlEntityType {
+    DOCUMENT_ENTITY,
+    EXTERNAL_PARSED_ENTITY
+}
+
+# Represents the XML DOCTYPE entity.
+#
+# + system - the system identifier
+# + public - the public identifier
+# + internalSubset - internal DTD schema
+type XmlDoctype record {|
+   string? system = ();
+   string? 'public = ();
+   string? internalSubset = ();
+|};
+
+# The writing options of an XML.
+#
+# + xmlEntityType - the entity type of the XML input(default value is `DOCUMENT_ENTITY`)
+# + doctype - XML DOCTYPE value(default value is null)
+public type XmlWriteOptions record {|
+    XmlEntityType xmlEntityType = DOCUMENT_ENTITY;
+    XmlDoctype? doctype = ();
+|};

--- a/io-ballerina/tests/resources/expectedXmlCharsFile4.xml
+++ b/io-ballerina/tests/resources/expectedXmlCharsFile4.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE note SYSTEM "Note.dtd">
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/io-ballerina/tests/resources/expectedXmlCharsFile5.xml
+++ b/io-ballerina/tests/resources/expectedXmlCharsFile5.xml
@@ -1,0 +1,6 @@
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note><body>Don't forget me this weekend!</body>

--- a/io-ballerina/tests/resources/expectedXmlCharsFile6.xml
+++ b/io-ballerina/tests/resources/expectedXmlCharsFile6.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE note [
+        <!ELEMENT note (to,from,heading,body)>
+        <!ELEMENT to (#PCDATA)>
+        <!ELEMENT from (#PCDATA)>
+        <!ELEMENT heading (#PCDATA)>
+        <!ELEMENT body (#PCDATA)>
+    ]>
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/io-ballerina/tests/resources/expectedXmlCharsFile7.xml
+++ b/io-ballerina/tests/resources/expectedXmlCharsFile7.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE note PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/io-ballerina/tests/resources/originalXmlContent.xml
+++ b/io-ballerina/tests/resources/originalXmlContent.xml
@@ -1,0 +1,6 @@
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/io-ballerina/tests/xml_io.bal
+++ b/io-ballerina/tests/xml_io.bal
@@ -264,7 +264,7 @@ function testFileWriteDocTypedWithMultiRoots() {
 
     var writeResult = fileWriteXml(filePath, xml:concat(content, x1));
     if (writeResult is Error) {
-        test:assertEquals(writeResult.message(), "The DOCUMENT XML can only contains single root");
+        test:assertEquals(writeResult.message(), "The XML Document can only contains single root");
     } else {
         test:assertFail("Expected ConfigurationError not found");
     }
@@ -278,7 +278,7 @@ function testFileWriteDocTypedWithAppend() {
     xml content = checkpanic fileReadXml(originalFilePath);
     var writeResult = fileWriteXml(filePath, content, fileWriteOption=APPEND);
     if (writeResult is Error) {
-        test:assertEquals(writeResult.message(), "The APPEND operation not allowed with DOCUMENT");
+        test:assertEquals(writeResult.message(), "The file append operation is not allowed for Document Entity");
     } else {
         test:assertFail("Expected ConfigurationError not found");
     }

--- a/io-ballerina/tests/xml_io.bal
+++ b/io-ballerina/tests/xml_io.bal
@@ -240,68 +240,57 @@ function testFileWriteXmlWithOverwrite() {
 @test:Config {}
 function testFileWriteDocTypedXml() {
     string filePath = TEMP_DIR + "xmlCharsFile4.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string resultFilePath = "tests/resources/expectedXmlCharsFile4.xml";
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+
+    xml content = checkpanic fileReadXml(originalFilePath);
     string doctypeValue = "<!DOCTYPE note SYSTEM \"Note.dtd\">";
     var writeResult = fileWriteXml(filePath, content, doctype={system:"Note.dtd"});
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
-    var readResult = fileReadString(filePath);
-    if (readResult is string) {
-        test:assertEquals(readResult, (xml:concat(doctypeValue, NEW_LINE, content)).toString());
-    } else {
-        test:assertFail(msg = readResult.message());
-    }
-
+    string readResult = checkpanic fileReadString(filePath);
+    string expectedResult = checkpanic fileReadString(resultFilePath);
+    test:assertEquals(readResult, expectedResult);
 }
 
 @test:Config {}
 function testFileWriteDocTypedWithMultiRoots() {
     string filePath = TEMP_DIR + "xmlCharsFile4.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+
+    xml content = checkpanic fileReadXml(originalFilePath);
     xml x1 = xml `<body>Don't forget me this weekend!</body>`;
 
     var writeResult = fileWriteXml(filePath, xml:concat(content, x1));
     if (writeResult is Error) {
         test:assertEquals(writeResult.message(), "The DOCUMENT XML can only contains single root");
+    } else {
+        test:assertFail("Expected ConfigurationError not found");
     }
 }
 
 @test:Config {}
 function testFileWriteDocTypedWithAppend() {
     string filePath = TEMP_DIR + "xmlCharsFile4.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
 
+    xml content = checkpanic fileReadXml(originalFilePath);
     var writeResult = fileWriteXml(filePath, content, fileWriteOption=APPEND);
     if (writeResult is Error) {
         test:assertEquals(writeResult.message(), "The APPEND operation not allowed with DOCUMENT");
+    } else {
+        test:assertFail("Expected ConfigurationError not found");
     }
 }
 
 @test:Config {}
 function testFileAppendDocTypedXml() {
     string filePath = TEMP_DIR + "xmlCharsFile5.xml";
-    xml content1 = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+    string resultFilePath = "tests/resources/expectedXmlCharsFile5.xml";
+
+    xml content1 = checkpanic fileReadXml(originalFilePath);
     xml content2 = xml `<body>Don't forget me this weekend!</body>`;
     var writeResult = fileWriteXml(filePath, content1);
     if (writeResult is Error) {
@@ -311,24 +300,18 @@ function testFileAppendDocTypedXml() {
     if (appendResult is Error) {
         test:assertFail(msg = appendResult.message());
     }
-    var readResult = fileReadString(filePath);
-    if (readResult is string) {
-        test:assertEquals(readResult,
-            (xml:concat(content1, content2)).toString());
-    } else {
-        test:assertFail(msg = readResult.message());
-    }
+    string readResult = checkpanic fileReadString(filePath);
+    string expectedResult = checkpanic fileReadString(resultFilePath);
+    test:assertEquals(readResult, expectedResult);
 }
 
 @test:Config {}
 function testFileWriteDocTypedXmlWithInternalSubset() {
     string filePath = TEMP_DIR + "xmlCharsFile6.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+    string resultFilePath = "tests/resources/expectedXmlCharsFile6.xml";
+
+    xml content = checkpanic fileReadXml(originalFilePath);
     string startElement = "<!DOCTYPE note ";
     string endElement = ">";
     string internalSub = string `[
@@ -342,23 +325,18 @@ function testFileWriteDocTypedXmlWithInternalSubset() {
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
-    var readResult = fileReadString(filePath);
-    if (readResult is string) {
-        test:assertEquals(readResult, (xml:concat(startElement, internalSub, endElement, NEW_LINE, content)).toString());
-    } else {
-        test:assertFail(msg = readResult.message());
-    }
+    string readResult = checkpanic fileReadString(filePath);
+    string expectedResult = checkpanic fileReadString(resultFilePath);
+    test:assertEquals(readResult, expectedResult);
 }
 
 @test:Config {}
 function testFileWriteDocTypedXmlWithPrioritizeInternalSubset() {
     string filePath = TEMP_DIR + "xmlCharsFile6.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+    string resultFilePath = "tests/resources/expectedXmlCharsFile6.xml";
+
+    xml content = checkpanic fileReadXml(originalFilePath);
     string startElement = "<!DOCTYPE note ";
     string endElement = ">";
     string systemId = "http://www.w3.org/TR/html4/loose.dtd";
@@ -373,23 +351,18 @@ function testFileWriteDocTypedXmlWithPrioritizeInternalSubset() {
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
-    var readResult = fileReadString(filePath);
-    if (readResult is string) {
-        test:assertEquals(readResult, (xml:concat(startElement, internalSub, endElement, NEW_LINE, content)).toString());
-    } else {
-        test:assertFail(msg = readResult.message());
-    }
+    string readResult = checkpanic fileReadString(filePath);
+    string expectedResult = checkpanic fileReadString(resultFilePath);
+    test:assertEquals(readResult, expectedResult);
 }
 
 @test:Config {}
 function testFileWriteDocTypedXmlWithPublic() {
     string filePath = TEMP_DIR + "xmlCharsFile7.xml";
-    xml content = xml `<note>
-    <to>Tove</to>
-    <from>Jani</from>
-    <heading>Reminder</heading>
-    <body>Don't forget me this weekend!</body>
-    </note>`;
+    string originalFilePath = "tests/resources/originalXmlContent.xml";
+    string resultFilePath = "tests/resources/expectedXmlCharsFile7.xml";
+
+    xml content = checkpanic fileReadXml(originalFilePath);
     string doctypeValue = "<!DOCTYPE note PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">";
     string publicId = "-//W3C//DTD HTML 4.01 Transitional//EN";
     string systemId = "http://www.w3.org/TR/html4/loose.dtd";
@@ -397,10 +370,7 @@ function testFileWriteDocTypedXmlWithPublic() {
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
-    var readResult = fileReadString(filePath);
-    if (readResult is string) {
-        test:assertEquals(readResult, (xml:concat(doctypeValue, NEW_LINE, content)).toString());
-    } else {
-        test:assertFail(msg = readResult.message());
-    }
+    string readResult = checkpanic fileReadString(filePath);
+    string expectedResult = checkpanic fileReadString(resultFilePath);
+    test:assertEquals(readResult, expectedResult);
 }

--- a/io-ballerina/tests/xml_io.bal
+++ b/io-ballerina/tests/xml_io.bal
@@ -383,7 +383,7 @@ function testFileWriteDocTypedXmlWithPrioritizeInternalSubset() {
 
 @test:Config {}
 function testFileWriteDocTypedXmlWithPublic() {
-    string filePath = TEMP_DIR + "xmlCharsFile6.xml";
+    string filePath = TEMP_DIR + "xmlCharsFile7.xml";
     xml content = xml `<note>
     <to>Tove</to>
     <from>Jani</from>


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/941

## Approach
Introduce XML writing options to the XML write API

- FileWriteOption - used to indicate whether to overwrite or append the content. Append only applicable when writing external parsed entities.
- XmlWriteOptions - to indicate XML doc type and entity type. The `xmlEntityType` to set the type of the document(document or external parsed entity).
- XmlDoctype - if an internal subset is specified, it is given priority over external ones and create the DOCTYPE declaration. If only the system is specified, it created a DOCTYPE declaration with SYSTEM. If public or (public and system) both specified, then it creates a DOCTYPE with PUBLIC.


## Automation tests
 - Unit tests 
   > Yes


## Samples
### Sample with SYSTEM
```ballerina 
import ballerina/io;

public function main() returns error? {
    xml content = xml `<note>
        <to>Tove</to>
        <from>Jani</from>
        <heading>Reminder</heading>
        <body>Don't forget me this weekend!</body>
        </note>`;
    check io:fileWriteXml("./sample.xml", content, doctype = {system: "Note.dtd"});
}
```

Output
```xml
<!DOCTYPE note SYSTEM "Note.dtd">
<note>
    <to>Tove</to>
    <from>Jani</from>
    <heading>Reminder</heading>
    <body>Don't forget me this weekend!</body>
</note>
```

### Sample with PUBLIC
```ballerina
import ballerina/io;

public function main() returns error? {
    xml content = xml `<note>
        <to>Tove</to>
        <from>Jani</from>
        <heading>Reminder</heading>
        <body>Don't forget me this weekend!</body>
        </note>`;
    string publicId = "-//W3C//DTD HTML 4.01 Transitional//EN";
    string systemId = "http://www.w3.org/TR/html4/loose.dtd";
    var writeResult = io:fileWriteXml("./sample.xml", content, doctype = {
        system: systemId,
        'public: publicId
    });
}
```

Output
```xml
<!DOCTYPE note PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<note>
    <to>Tove</to>
    <from>Jani</from>
    <heading>Reminder</heading>
    <body>Don't forget me this weekend!</body>
</note>
```

### Sample with Internal Declaration
```ballerina
import ballerina/io;

public function main() returns error? {
    xml content = xml `<note>
        <to>Tove</to>
        <from>Jani</from>
        <heading>Reminder</heading>
        <body>Don't forget me this weekend!</body>
        </note>`;
    string internalSub = string `[
        <!ELEMENT note (to,from,heading,body)>
        <!ELEMENT to (#PCDATA)>
        <!ELEMENT from (#PCDATA)>
        <!ELEMENT heading (#PCDATA)>
        <!ELEMENT body (#PCDATA)>
    ]`;
    var writeResult = io:fileWriteXml(filePath, content, doctype = {
        internalSubset: internalSub,
        system: systemId
    });
}
```

Output
```xml
<!DOCTYPE note [
        <!ELEMENT note (to,from,heading,body)>
        <!ELEMENT to (#PCDATA)>
        <!ELEMENT from (#PCDATA)>
        <!ELEMENT heading (#PCDATA)>
        <!ELEMENT body (#PCDATA)>
    ]>
<note>
    <to>Tove</to>
    <from>Jani</from>
    <heading>Reminder</heading>
    <body>Don't forget me this weekend!</body>
</note>
```

## Test environment
- macOS
- SLAlpha 3
- Java11
 
## Learning
- https://www.w3.org/TR/xml/#NT-doctypedecl
- https://www.liquid-technologies.com/XML/DocType.aspx