### PR TITLE
Fixed the windows build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,4 +43,5 @@ jobs:
                 env:
                     packageUser: ${{ github.actor }}
                     packagePAT: ${{ secrets.GITHUB_TOKEN }}
+                    JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
                 run: ./gradlew.bat build --scan --no-daemon

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,4 +43,4 @@ jobs:
                 env:
                     packageUser: ${{ github.actor }}
                     packagePAT: ${{ secrets.GITHUB_TOKEN }}
-                run: ./gradlew.bat build -x test --scan --no-daemon
+                run: ./gradlew.bat build --scan --no-daemon

--- a/io-ballerina/tests/bytes_io.bal
+++ b/io-ballerina/tests/bytes_io.bal
@@ -18,6 +18,11 @@ import ballerina/jballerina.java;
 import ballerina/test;
 import ballerina/lang.'string as langstring;
 
+@test:BeforeSuite
+function beforeFunc() {
+     createDirectoryExtern(TEMP_DIR);
+}
+
 @test:Config {}
 function testReadBytes() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/charfile.txt";
@@ -82,7 +87,6 @@ function testWriteBytes() {
 @test:Config {}
 function testFileWriteBytes() {
     string filePath = TEMP_DIR + "bytesFile2.txt";
-    createDirectoryExtern(TEMP_DIR);
     string content = "Sheldon Cooper";
     var result = fileWriteBytes(filePath, content.toBytes());
 
@@ -146,7 +150,6 @@ function testFileReadBytesAsStream() {
 @test:Config {}
 function testFileChannelWriteBytes() {
     string filePath = TEMP_DIR + "bytesFile4.txt";
-    createDirectoryExtern(TEMP_DIR);
     string content = "Sheldon Cooper";
 
     var fileOpenResult = openWritableFile(filePath);
@@ -247,7 +250,6 @@ function testFileCopy() {
 @test:Config {}
 function testFileWriteBytesWithOverwrite() {
     string filePath = TEMP_DIR + "bytesFile6.txt";
-    createDirectoryExtern(TEMP_DIR);
     string content1 = "Ballerina is an open source programming language and " +
     "platform for cloud-era application programmers to easily write software that just works.";
     string content2 = "Ann Johnson is a banker.";
@@ -280,7 +282,6 @@ function testFileWriteBytesWithOverwrite() {
 @test:Config {}
 function testFileWriteBytesWithAppend() {
     string filePath = TEMP_DIR + "bytesFile7.txt";
-    createDirectoryExtern(TEMP_DIR);
     string content1 = "Ballerina is an open source programming language and " +
     "platform for cloud-era application programmers to easily write software that just works. ";
     string content2 = "Ann Johnson is a banker.";
@@ -313,7 +314,6 @@ function testFileWriteBytesWithAppend() {
 @test:Config {}
 function testFileWriteBytesFromStreamWithOverride() {
     string filePath = TEMP_DIR + "bytesFile8.txt";
-    createDirectoryExtern(TEMP_DIR);
     string[] content1 = ["Ballerina ", "is ", "an "];
     string[] content2 = ["open ", "source ", "programming ", "language"];
     string expectedContent1 = "Ballerina is an ";
@@ -380,7 +380,6 @@ function testFileWriteBytesFromStreamWithOverride() {
 @test:Config {}
 function testFileWriteBytesFromStreamWithAppend() {
     string filePath = TEMP_DIR + "bytesFile8.txt";
-    createDirectoryExtern(TEMP_DIR);
     string[] content1 = ["Ballerina ", "is ", "an "];
     string[] content2 = ["open ", "source ", "programming ", "language"];
     string expectedContent1 = "Ballerina is an ";

--- a/io-ballerina/tests/json_io.bal
+++ b/io-ballerina/tests/json_io.bal
@@ -150,7 +150,6 @@ function testFileWriteJsonWithTruncate() {
 @test:Config {}
 function testWriteHigherUnicodeJson() {
     string filePath = TEMP_DIR + "higherUniJsonCharsFile.json";
-    createDirectoryExtern(TEMP_DIR);
     json content = {"loop": "É"};
 
     var byteChannel = openWritableFile(filePath);
@@ -173,7 +172,6 @@ function testWriteHigherUnicodeJson() {
 @test:Config {dependsOn: [testWriteHigherUnicodeJson]}
 function testReadHigherUnicodeJson() {
     string filePath = TEMP_DIR + "higherUniJsonCharsFile.json";
-    createDirectoryExtern(TEMP_DIR);
     json expectedJson = {"loop": "É"};
     var byteChannel = openReadableFile(filePath);
     if (byteChannel is ReadableByteChannel) {

--- a/io-ballerina/tests/text_io.bal
+++ b/io-ballerina/tests/text_io.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/jballerina.java;
 import ballerina/test;
 
 @test:Config {}
@@ -61,7 +62,8 @@ function testReadCharacters() {
 function testReadAllCharacters() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/fileThatExceeds2MB.txt";
     string result = "";
-    int expectedNumberOfCharacters = 2265223;
+    int expectedNumberOfCharsInWindows = 2297329;
+    int expectedNumberOfCharsInLinux = 2265223;
     int fixedSize = 500;
     boolean isDone = false;
 
@@ -82,7 +84,11 @@ function testReadAllCharacters() {
                 }
             }
         }
-        test:assertEquals(result.length(), expectedNumberOfCharacters);
+        if (isWindowsEnvironment()) {
+            test:assertEquals(result.length(), expectedNumberOfCharsInWindows);
+        } else {
+            test:assertEquals(result.length(), expectedNumberOfCharsInLinux);
+        }
 
         var closeResult = characterChannel.close();
         if (closeResult is Error) {
@@ -679,3 +685,8 @@ function testFileChannelReadLinesWithByteChannel() {
         test:assertFail(msg = fileOpenResult.message());
     }
 }
+
+function isWindowsEnvironment() returns boolean = @java:Method {
+    name: "isWindowsEnvironment",
+    'class: "org.ballerinalang.stdlib.io.testutils.EnvironmentTestUtils"
+} external;

--- a/io-ballerina/tests/text_io.bal
+++ b/io-ballerina/tests/text_io.bal
@@ -16,7 +16,7 @@
 
 import ballerina/test;
 
-@test:Config {dependsOn: [testWriteBytes]}
+@test:Config {}
 function testReadCharacters() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/utf8file.txt";
     string expectedCharacters = "aaa";
@@ -57,7 +57,7 @@ function testReadCharacters() {
     }
 }
 
-@test:Config {dependsOn: [testReadCharacters]}
+@test:Config {}
 function testReadAllCharacters() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/fileThatExceeds2MB.txt";
     string result = "";
@@ -93,7 +93,7 @@ function testReadAllCharacters() {
     }
 }
 
-@test:Config {dependsOn: [testReadAllCharacters]}
+@test:Config {}
 function testReadAllCharactersFromEmptyFile() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/emptyFile.txt";
     string result = "";
@@ -129,7 +129,7 @@ function testReadAllCharactersFromEmptyFile() {
     }
 }
 
-@test:Config {dependsOn: [testReadAllCharactersFromEmptyFile]}
+@test:Config {}
 function testWriteCharacters() {
     string filePath = TEMP_DIR + "characterFile.txt";
     string content = "The quick brown fox jumps over the lazy dog";
@@ -221,7 +221,7 @@ function testReadAvailableProperty() {
     }
 }
 
-@test:Config {dependsOn: [testReadAvailableProperty]}
+@test:Config {}
 function testAllProperties() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/person.properties";
 
@@ -242,7 +242,7 @@ function testAllProperties() {
     }
 }
 
-@test:Config {dependsOn: [testAllProperties]}
+@test:Config {}
 function testReadUnavailableProperty() {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/person.properties";
     string defaultValue = "Default";
@@ -266,7 +266,7 @@ function testReadUnavailableProperty() {
     }
 }
 
-@test:Config {dependsOn: [testReadUnavailableProperty]}
+@test:Config {}
 function testWriteProperties() {
     string filePath = TEMP_DIR + "/tmp_person.properties";
     map<string> properties = {

--- a/io-ballerina/tests/xml_io.bal
+++ b/io-ballerina/tests/xml_io.bal
@@ -18,7 +18,6 @@ import ballerina/test;
 @test:Config {}
 function testWriteXml() {
     string filePath = TEMP_DIR + "xmlCharsFile1.xml";
-    createDirectoryExtern(TEMP_DIR);
     xml content = xml `<CATALOG>
                        <CD>
                            <TITLE>Empire Burlesque</TITLE>

--- a/io-test-utils/src/main/java/org/ballerinalang/stdlib/io/testutils/EnvironmentTestUtils.java
+++ b/io-test-utils/src/main/java/org/ballerinalang/stdlib/io/testutils/EnvironmentTestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.io.testutils;
+
+import java.util.Locale;
+
+/**
+ * This class holds test utility APIs related to check the running OS.
+ *
+ */
+public class EnvironmentTestUtils {
+
+    public static boolean isWindowsEnvironment() {
+        return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/183

## Approach
- Enable UTF-8 encoding JVM options in the windows build
    - Otherwise, it would take the default Windows encoding. Then the similar tests cannot be run in Windows and Linux because the expected values depend on the encoding type.
- Change the expected character count according to the OS
    - In windows, a new line represents using two characters. Therefore, in windows expected character count is:
      ```
      CharCountInWindows = CharCountInLinux + NoOfNewLineCharsInFile = CharCountInLinux + (NoOfLines - 1)
      ```

## Automation tests
 - Unit tests 
   > Yes

## Test environment
- Java11
- SLAlpha4
- MacOS, Linux, and Windows
 
## Learning
https://stackoverflow.com/questions/63445961/counting-characters-a-java-program-and-wc-yield-inconsistent-results