### PR TITLE
Make `XmlDoctype` publicly accessible

### DIFF
--- a/io-ballerina/options.bal
+++ b/io-ballerina/options.bal
@@ -37,7 +37,7 @@ public enum XmlEntityType {
 # + system - the system identifier
 # + public - the public identifier
 # + internalSubset - internal DTD schema
-type XmlDoctype record {|
+public type XmlDoctype record {|
    string? system = ();
    string? 'public = ();
    string? internalSubset = ();


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/983

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/77

## Test environment
- Ballerina SLAlpha4-SNAPSHOT
- macOS
- Java 11