### PR TITLE
Fix unnecessary character generation in the XML DOCTYPE

### DIFF
--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -145,10 +145,15 @@ function channelWriteJson(WritableChannel writableChannel, json content) returns
     }
 }
 
-function channelWriteXml(WritableChannel writableChannel, xml content) returns Error? {
+function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
-        var writeResult = characterChannel.writeXml(content);
+        Error? writeResult = ();
+        if (xmlDoctype != ()) {
+            writeResult = characterChannel.writeXml(content, <XmlDoctype>xmlDoctype);
+        } else {
+            writeResult = characterChannel.writeXml(content);
+        }
         if (writeResult is Error) {
             return writeResult;
         }

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
@@ -52,6 +52,7 @@ public class CharacterChannelUtils {
 
     private static final Logger log = LoggerFactory.getLogger(CharacterChannelUtils.class);
     private static final String BUFFERED_READER_ENTRY = "bufferedReader";
+    private static final String NEW_LINE = "\n";
 
     private CharacterChannelUtils() {
     }
@@ -213,11 +214,17 @@ public class CharacterChannelUtils {
         return null;
     }
 
-    public static Object writeXml(BObject characterChannelObj, BXml content) {
+    public static Object writeXml(BObject characterChannelObj, BXml content, BString doctype) {
         try {
             CharacterChannel characterChannel = (CharacterChannel) characterChannelObj
                     .getNativeData(CHARACTER_CHANNEL_NAME);
-            IOUtils.writeFull(characterChannel, content.toString());
+            String writeContent = "";
+            if (doctype.getValue().isBlank()) {
+                writeContent = content.toString();
+            } else {
+                writeContent = doctype.getValue() + NEW_LINE + content.toString();
+            }
+            IOUtils.writeFull(characterChannel, writeContent);
         } catch (BallerinaIOException e) {
             return IOUtils.createError(e);
         }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1032

## Approach
Previously, we created the final XML to be written after concatenating the DOCTYPE block. The previous concatenation achieved using `xml:concat` API.

Recently, Ballerina language XML APIs pass these concatenation strings through an XML serializer. Therefore, these XML strings add special characters after serialization.

To solve that we need to directly write XML DOCTYPE block in the Java native level.

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/77

## Test environment
- Java 11
- Swan Lake 3
- macOS