### PR TITLE
Make abstract ReadableChannel and WritableChannel types private

### DIFF
--- a/io-ballerina/channel.bal
+++ b/io-ballerina/channel.bal
@@ -14,6 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type ReadableChannel ReadableByteChannel|ReadableCharacterChannel|ReadableTextRecordChannel|ReadableCSVChannel;
+type ReadableChannel ReadableByteChannel|ReadableCharacterChannel|ReadableTextRecordChannel|ReadableCSVChannel;
 
-public type WritableChannel WritableByteChannel|WritableCharacterChannel|WritableTextRecordChannel|WritableCSVChannel;
+type WritableChannel WritableByteChannel|WritableCharacterChannel|WritableTextRecordChannel|WritableCSVChannel;


### PR DESCRIPTION
## Purpose
Since the channel APIs are now private, we don't need these types to be public.

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/41

## Test environment
- macOS
- Java 11