### PR TITLE
Generate Codecov Report

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,6 +33,8 @@ jobs:
                     name: Ballerina Internal Log
                     path: io-ballerina/ballerina-internal.log
                     if-no-files-found: ignore
+            -   name: Generate Codecov Report
+                uses: codecov/codecov-action@v1
             -   name: Dispatch Dependent Module Builds
                 if: github.event.action != 'stdlib-publish-snapshot'
                 run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,9 @@ jobs:
                     name: Ballerina Internal Log
                     path: io-ballerina/ballerina-internal.log
                     if-no-files-found: ignore
+            -   name: Generate Codecov Report
+                if: github.event_name == 'pull_request'
+                uses: codecov/codecov-action@v1
 
     windows-build:
         runs-on: windows-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/io/*/::io-ballerina/"
+
+ignore:
+  - "**/tests"
+  - "io-test-utils/"


### PR DESCRIPTION
## Purpose

- Introducing Codecov code coverage report publishing to the `io` repository

## Goals

- Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach

- A new job is inserted to Pull request and Build GitHub actions that publishes the XML report to Codecov.
- These jobs trigger on push or pull request and CodeCov generates a descriptive code coverage report.
- Codecov also adds comments to any PR made based on the code coverage changes between commits

## Test environment

- Ubuntu 20.04
