### PR TITLE
Make I/O read and write APIs isolated

### DIFF
--- a/io-ballerina/block_stream.bal
+++ b/io-ballerina/block_stream.bal
@@ -29,7 +29,7 @@ public class BlockStream {
     #
     # + readableByteChannel - The `io:ReadableByteChannel` that this block stream is referred to
     # + blockSize - The size of a block as an integer
-    public function init(ReadableByteChannel readableByteChannel, int blockSize) {
+    public isolated function init(ReadableByteChannel readableByteChannel, int blockSize) {
         self.readableByteChannel = readableByteChannel;
         self.blockSize = blockSize;
     }

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -16,7 +16,7 @@
 
 import ballerina/lang.'value;
 
-function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
+isolated function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readString();
@@ -27,7 +27,7 @@ function channelReadString(ReadableChannel readableChannel) returns @tainted str
     }
 }
 
-function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
+isolated function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readAllLines();
@@ -38,7 +38,7 @@ function channelReadLines(ReadableChannel readableChannel) returns @tainted stri
     }
 }
 
-function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
+isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         return characterChannel.lineStream();
@@ -47,7 +47,7 @@ function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tain
     }
 }
 
-function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
+isolated function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readJson();
@@ -58,7 +58,7 @@ function channelReadJson(ReadableChannel readableChannel) returns @tainted json|
     }
 }
 
-function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
+isolated function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
     var characterChannel = getReadableCharacterChannel(readableChannel);
     if (characterChannel is ReadableCharacterChannel) {
         var result = characterChannel.readXml();
@@ -69,7 +69,7 @@ function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Er
     }
 }
 
-function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
+isolated function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         var writeResult = characterChannel.write(content, 0);
@@ -86,7 +86,7 @@ function channelWriteString(WritableChannel writableChannel, string content) ret
     }
 }
 
-function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
+isolated function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         string writeContent = "";
@@ -107,18 +107,18 @@ function channelWriteLines(WritableChannel writableChannel, string[] content) re
     }
 }
 
-function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns Error? {
+isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
-        error? e = lineStream.forEach(function(string stringContent) {
-                                          if (characterChannel is WritableCharacterChannel) {
-                                              var r = characterChannel.writeLine(stringContent);
-                                          }
-                                      });
-        if (e is Error) {
-            return e;
+        record {| string value; |}|Error? line = lineStream.next();
+        while(line is record {| string value; |}) {
+            var writeResult = characterChannel.writeLine(line.value);
+            line = lineStream.next();
         }
         var closeResult = characterChannel.close();
+        if (line is Error) {
+            return line;
+        }
         if (closeResult is Error) {
             return closeResult;
         }
@@ -128,7 +128,7 @@ function channelWriteLinesFromStream(WritableChannel writableChannel, stream<str
     }
 }
 
-function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
+isolated function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         var writeResult = characterChannel.writeJson(content);
@@ -145,7 +145,7 @@ function channelWriteJson(WritableChannel writableChannel, json content) returns
     }
 }
 
-function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
+isolated function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
     var characterChannel = getWritableCharacterChannel(writableChannel);
     if (characterChannel is WritableCharacterChannel) {
         Error? writeResult = ();
@@ -167,7 +167,7 @@ function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctyp
     }
 }
 
-function getReadableCharacterChannel(ReadableChannel readableChannel) returns ReadableCharacterChannel|Error {
+isolated function getReadableCharacterChannel(ReadableChannel readableChannel) returns ReadableCharacterChannel|Error {
     ReadableCharacterChannel readableCharacterChannel;
     if (readableChannel is ReadableByteChannel) {
         readableCharacterChannel = new (readableChannel, DEFAULT_ENCODING);
@@ -181,7 +181,7 @@ function getReadableCharacterChannel(ReadableChannel readableChannel) returns Re
     return readableCharacterChannel;
 }
 
-function getWritableCharacterChannel(WritableChannel writableChannel) returns WritableCharacterChannel|Error {
+isolated function getWritableCharacterChannel(WritableChannel writableChannel) returns WritableCharacterChannel|Error {
     WritableCharacterChannel writableCharacterChannel;
     if (writableChannel is WritableByteChannel) {
         writableCharacterChannel = new (writableChannel, DEFAULT_ENCODING);

--- a/io-ballerina/csv_stream.bal
+++ b/io-ballerina/csv_stream.bal
@@ -25,7 +25,7 @@ public class CSVStream {
     # Initialize a `CSVStream` using a `io:ReadableTextRecordChannel`.
     #
     # + readableTextRecordChannel - The `io:ReadableTextRecordChannel` that this CSV stream is referred to
-    public function init(ReadableTextRecordChannel readableTextRecordChannel) {
+    public isolated function init(ReadableTextRecordChannel readableTextRecordChannel) {
         self.readableTextRecordChannel = readableTextRecordChannel;
     }
 

--- a/io-ballerina/file_byte_io.bal
+++ b/io-ballerina/file_byte_io.bal
@@ -20,7 +20,7 @@
 # ```
 # + path - The path of the file
 # + return - Either a read only byte array or `io:Error`
-public function fileReadBytes(@untainted string path) returns @tainted readonly & byte[]|Error {
+public isolated function fileReadBytes(@untainted string path) returns @tainted readonly & byte[]|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadBytes(byteChannel);
@@ -36,7 +36,7 @@ public function fileReadBytes(@untainted string path) returns @tainted readonly 
 # + path - The path of the file
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
-public function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block, Error>|Error {
+public isolated function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block, Error>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadBlocksAsStream(byteChannel, blockSize);
@@ -54,7 +54,7 @@ public function fileReadBlocksAsStream(string path, int blockSize=4096) returns 
 # + content - Byte content to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - `io:Error` or else `()`
-public function fileWriteBytes(@untainted string path, byte[] content,
+public isolated function fileWriteBytes(@untainted string path, byte[] content,
                             FileWriteOption option = OVERWRITE) returns Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
@@ -74,7 +74,7 @@ public function fileWriteBytes(@untainted string path, byte[] content,
 # + byteStream - Byte stream to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - `io:Error` or else `()`
-public function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream,
+public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream,
                         FileWriteOption option = OVERWRITE) returns Error? {
 
     var byteChannel = openWritableFile(path, option);

--- a/io-ballerina/file_csv_io.bal
+++ b/io-ballerina/file_csv_io.bal
@@ -21,7 +21,7 @@
 # + path - The CSV file path
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
 # + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
-public function fileReadCsv(@untainted string path, int skipHeaders = 0) returns @tainted string[][]|Error {
+public isolated function fileReadCsv(@untainted string path, int skipHeaders = 0) returns @tainted string[][]|Error {
 
     var csvChannel = openReadableCsvFile(path, COMMA, DEFAULT_ENCODING, skipHeaders);
     if (csvChannel is ReadableCSVChannel) {
@@ -37,7 +37,7 @@ public function fileReadCsv(@untainted string path, int skipHeaders = 0) returns
 # ```
 # + path - The CSV file path
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
-public function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error>|Error {
+public isolated function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error>|Error {
     var csvChannel = openReadableCsvFile(path);
     if (csvChannel is ReadableCSVChannel) {
         return csvChannel.csvStream();
@@ -55,7 +55,7 @@ public function fileReadCsvAsStream(@untainted string path) returns @tainted str
 # + content - CSV content as an array of string arrays
 # + option - To indicate whether to overwrite or append the given content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public function fileWriteCsv(@untainted string path, string[][] content,
+public isolated function fileWriteCsv(@untainted string path, string[][] content,
                         FileWriteOption option = OVERWRITE) returns Error? {
     var csvChannel = openWritableCsvFile(path, option=option);
     if (csvChannel is WritableCSVChannel) {
@@ -75,7 +75,7 @@ public function fileWriteCsv(@untainted string path, string[][] content,
 # + content - A CSV record stream to be written
 # + option - To indicate whether to overwrite or append the given content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content,
+public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content,
                     FileWriteOption option = OVERWRITE) returns Error? {
     var csvChannel = openWritableCsvFile(path, option=option);
     if (csvChannel is WritableCSVChannel) {

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -20,7 +20,7 @@
 # ```
 # + path - The path of the file
 # + return - The entire file content as a string or an `io:Error`
-public function fileReadString(@untainted string path) returns @tainted string|Error {
+public isolated function fileReadString(@untainted string path) returns @tainted string|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadString(byteChannel);
@@ -35,7 +35,7 @@ public function fileReadString(@untainted string path) returns @tainted string|E
 # ```
 # + path - The path of the file
 # + return - The file as list of lines or an `io:Error`
-public function fileReadLines(@untainted string path) returns @tainted string[]|Error {
+public isolated function fileReadLines(@untainted string path) returns @tainted string[]|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadLines(byteChannel);
@@ -50,7 +50,7 @@ public function fileReadLines(@untainted string path) returns @tainted string[]|
 # ```
 # + path - The path of the file
 # + return - The file content as a stream of strings or an `io:Error`
-public function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error>|Error {
+public isolated function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error>|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadLinesAsStream(byteChannel);
@@ -65,7 +65,7 @@ public function fileReadLinesAsStream(@untainted string path) returns @tainted s
 # ```
 # + path - The path of the JSON file
 # + return - The file content as a JSON object or an `io:Error`
-public function fileReadJson(@untainted string path) returns @tainted json|Error {
+public isolated function fileReadJson(@untainted string path) returns @tainted json|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadJson(byteChannel);
@@ -80,7 +80,7 @@ public function fileReadJson(@untainted string path) returns @tainted json|Error
 # ```
 # + path - The path of the XML file
 # + return - The file content as an XML or an `io:Error`
-public function fileReadXml(@untainted string path) returns @tainted xml|Error {
+public isolated function fileReadXml(@untainted string path) returns @tainted xml|Error {
     var byteChannel = openReadableFile(path);
     if (byteChannel is ReadableByteChannel) {
         return channelReadXml(byteChannel);
@@ -98,7 +98,7 @@ public function fileReadXml(@untainted string path) returns @tainted xml|Error {
 # + content - String content to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns
+public isolated function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns
 Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
@@ -118,7 +118,7 @@ Error? {
 # + content - An array of string lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns
+public isolated function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns
 Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
@@ -139,7 +139,7 @@ Error? {
 # + lineStream -  A stream of lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, FileWriteOption option =
+public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, FileWriteOption option =
                                          OVERWRITE) returns Error? {
     var byteChannel = openWritableFile(path, option);
     if (byteChannel is WritableByteChannel) {
@@ -157,7 +157,7 @@ public function fileWriteLinesFromStream(@untainted string path, stream<string, 
 # + path - The path of the JSON file
 # + content - JSON content to write
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteJson(@untainted string path, json content) returns @tainted Error? {
+public isolated function fileWriteJson(@untainted string path, json content) returns @tainted Error? {
     var byteChannel = openWritableFile(path);
     if (byteChannel is WritableByteChannel) {
         return channelWriteJson(byteChannel, content);
@@ -176,7 +176,7 @@ public function fileWriteJson(@untainted string path, json content) returns @tai
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
 # + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption =
+public isolated function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption =
                              OVERWRITE) returns Error? {
     WritableByteChannel|Error byteChannel;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {

--- a/io-ballerina/line_stream.bal
+++ b/io-ballerina/line_stream.bal
@@ -25,7 +25,7 @@ public class LineStream {
     # Initialize a `LineStream` using a `io:ReadableCharacterChannel`.
     #
     # + readableCharacterChannel - The `io:ReadableCharacterChannel` that this line stream is referred to
-    public function init(ReadableCharacterChannel readableCharacterChannel) {
+    public isolated function init(ReadableCharacterChannel readableCharacterChannel) {
         self.readableCharacterChannel = readableCharacterChannel;
     }
 

--- a/io-ballerina/open.bal
+++ b/io-ballerina/open.bal
@@ -23,7 +23,7 @@ import ballerina/jballerina.java;
 #
 # + path - Relative/absolute path string to locate the file
 # + return - The `ByteChannel` representation of the file resource or else an `io:Error` if any error occurred
-public function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
+public isolated function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
     name: "openReadableFile",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
@@ -36,7 +36,7 @@ public function openReadableFile(@untainted string path) returns ReadableByteCha
 # + path - Relative/absolute path string to locate the file
 # + option - To indicate whether to overwrite or append the given content
 # + return - The `ByteChannel` representation of the file resource or else an `io:Error` if any error occurred
-public function openWritableFile(@untainted string path, FileWriteOption option = OVERWRITE)
+public isolated function openWritableFile(@untainted string path, FileWriteOption option = OVERWRITE)
     returns WritableByteChannel|Error = @java:Method {
     name: "openWritableFile",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
@@ -49,7 +49,7 @@ public function openWritableFile(@untainted string path, FileWriteOption option 
 #
 # + content - Content, which should be exposed as a channel
 # + return - The `ByteChannel` representation to read the memory content or else an `io:Error` if any error occurred
-public function createReadableChannel(byte[] content) returns ReadableByteChannel|Error = @java:Method {
+public isolated function createReadableChannel(byte[] content) returns ReadableByteChannel|Error = @java:Method {
     name: "createReadableChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
@@ -64,7 +64,7 @@ public function createReadableChannel(byte[] content) returns ReadableByteChanne
 # + charset - Representation of the encoding characters in the file
 # + skipHeaders - Number of headers, which should be skipped
 # + return - The `ReadableCSVChannel`, which could be used to iterate through the CSV records or else an `io:Error` if any error occurred
-public function openReadableCsvFile(@untainted string path,
+public isolated function openReadableCsvFile(@untainted string path,
                                     @untainted Separator fieldSeparator = ",",
                                     @untainted string charset = "UTF-8",
                                     @untainted int skipHeaders = 0) returns ReadableCSVChannel|Error {
@@ -84,7 +84,7 @@ public function openReadableCsvFile(@untainted string path,
 # + skipHeaders - Number of headers, which should be skipped
 # + option - To indicate whether to overwrite or append the given content
 # + return - The `WritableCSVChannel`, which could be used to write the CSV records or else an `io:Error` if any error occurred
-public function openWritableCsvFile(@untainted string path,
+public isolated function openWritableCsvFile(@untainted string path,
                                     @untainted Separator fieldSeparator = ",",
                                     @untainted string charset = "UTF-8",
                                     @untainted int skipHeaders = 0,

--- a/io-ballerina/readable_byte_channel.bal
+++ b/io-ballerina/readable_byte_channel.bal
@@ -24,7 +24,7 @@ import ballerina/jballerina.java;
 public class ReadableByteChannel {
 
     # Adding default init function to prevent object getting initialized from the user code.
-    function init() {
+    isolated function init() {
     }
 
     # Source bytes from a given input resource.
@@ -36,7 +36,7 @@ public class ReadableByteChannel {
     #
     # + nBytes - A positive integer. Represents the number of bytes, which should be read
     # + return - Content (the number of bytes) read, an `EofError` once the channel reaches the end or else an `io:Error`
-    public function read(@untainted int nBytes) returns @tainted byte[]|Error {
+    public isolated function read(@untainted int nBytes) returns @tainted byte[]|Error {
         return byteReadExtern(self, nBytes);
     }
 
@@ -46,7 +46,7 @@ public class ReadableByteChannel {
     # ```
     #
     # + return - Either a read only `byte` array or else an `io:Error`
-    public function readAll() returns @tainted readonly & byte[]|Error {
+    public isolated function readAll() returns @tainted readonly & byte[]|Error {
         var readResult = readAllBytes(self);
         if (readResult is byte[]) {
             return <readonly & byte[]>readResult.cloneReadOnly();
@@ -61,7 +61,7 @@ public class ReadableByteChannel {
     # ```
     # + blockSize - A positive integer. Size of the block.
     # + return - Either a block stream or else an `io:Error`
-    public function blockStream(int blockSize) returns @tainted stream<Block, Error>|Error {
+    public isolated function blockStream(int blockSize) returns @tainted stream<Block, Error>|Error {
         BlockStream blockStream = new (self, blockSize);
         return new stream<Block, Error>(blockStream);
     }
@@ -72,7 +72,7 @@ public class ReadableByteChannel {
     # ```
     #
     # + return - An encoded `ReadableByteChannel` or else an `io:Error`
-    public function base64Encode() returns ReadableByteChannel|Error {
+    public isolated function base64Encode() returns ReadableByteChannel|Error {
         return base64EncodeExtern(self);
     }
 
@@ -82,7 +82,7 @@ public class ReadableByteChannel {
     # ```
     #
     # + return - A decoded `ReadableByteChannel` or else an `io:Error`
-    public function base64Decode() returns ReadableByteChannel|Error {
+    public isolated function base64Decode() returns ReadableByteChannel|Error {
         return base64DecodeExtern(self);
     }
 
@@ -93,32 +93,32 @@ public class ReadableByteChannel {
     # ```
     #
     # + return - Will return `()` if there is no error
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeReadableByteChannelExtern(self);
     }
 }
 
-function byteReadExtern(ReadableByteChannel byteChannel, @untainted int nBytes) returns @tainted byte[]|Error = @java:Method {
+isolated function byteReadExtern(ReadableByteChannel byteChannel, @untainted int nBytes) returns @tainted byte[]|Error = @java:Method {
     name: "read",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
-function readAllBytes(ReadableByteChannel byteChannel) returns @tainted byte[]|Error = @java:Method {
+isolated function readAllBytes(ReadableByteChannel byteChannel) returns @tainted byte[]|Error = @java:Method {
     name: "readAll",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
-function base64EncodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
+isolated function base64EncodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
     name: "base64Encode",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
-function base64DecodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
+isolated function base64DecodeExtern(ReadableByteChannel byteChannel) returns ReadableByteChannel|Error = @java:Method {
     name: "base64Decode",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
-function closeReadableByteChannelExtern(ReadableByteChannel byteChannel) returns Error? = @java:Method {
+isolated function closeReadableByteChannelExtern(ReadableByteChannel byteChannel) returns Error? = @java:Method {
     name: "closeByteChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;

--- a/io-ballerina/readable_character_channel.bal
+++ b/io-ballerina/readable_character_channel.bal
@@ -26,7 +26,7 @@ public class ReadableCharacterChannel {
     # 
     # + byteChannel - The `ReadableByteChannel`, which would be used to read the characters
     # + charset - The character set, which would be used to encode/decode the given bytes to characters
-    public function init(ReadableByteChannel byteChannel, string charset) {
+    public isolated function init(ReadableByteChannel byteChannel, string charset) {
         self.byteChannel = byteChannel;
         self.charset = charset;
         initReadableCharacterChannel(self, byteChannel, charset);
@@ -40,7 +40,7 @@ public class ReadableCharacterChannel {
     #
     # + numberOfChars - Number of characters, which should be read
     # + return - Content, which is read, an `EofError` once the channel reaches the end or else an `io:Error`
-    public function read(@untainted int numberOfChars) returns @tainted string|Error {
+    public isolated function read(@untainted int numberOfChars) returns @tainted string|Error {
         return readExtern(self, numberOfChars);
     }
 
@@ -49,7 +49,7 @@ public class ReadableCharacterChannel {
     # string|io:Error content = readableCharChannel.readString();
     # ```
     # + return - Either a string or `io:Error`
-    public function readString() returns @tainted string|Error {
+    public isolated function readString() returns @tainted string|Error {
         return readAllAsStringExtern(self);
     }
 
@@ -58,7 +58,7 @@ public class ReadableCharacterChannel {
     # string[]|io:Error content = readableCharChannel.readAllLines();
     # ```
     # + return - Either a string array or `io:Error`
-    public function readAllLines() returns @tainted string[]|Error {
+    public isolated function readAllLines() returns @tainted string[]|Error {
         return readAllLinesExtern(self);
     }
 
@@ -68,7 +68,7 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - The read JSON string or else an `io:Error`
-    public function readJson() returns @tainted json|Error {
+    public isolated function readJson() returns @tainted json|Error {
         return readJsonExtern(self);
     }
 
@@ -78,7 +78,7 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - The read XML or else an `io:Error`
-    public function readXml() returns @tainted xml|Error {
+    public isolated function readXml() returns @tainted xml|Error {
         return readXmlExtern(self);
     }
 
@@ -89,7 +89,7 @@ public class ReadableCharacterChannel {
     # + key - The property key needs to read.
     # + defaultValue - Default value to be return.
     # + return - The read property value or else an `io:Error`
-    public function readProperty(string key, string defaultValue = "") returns @tainted string|Error {
+    public isolated function readProperty(string key, string defaultValue = "") returns @tainted string|Error {
         return readPropertyExtern(self, key, defaultValue);
     }
 
@@ -99,7 +99,7 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - Either a stream of strings(lines) or an io:Error.
-    public function lineStream() returns stream<string, Error>|Error {
+    public isolated function lineStream() returns stream<string, Error>|Error {
         LineStream lineStream = new (self);
         return new stream<string, Error>(lineStream);
     }
@@ -110,7 +110,7 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - A map that contains all properties
-    public function readAllProperties() returns @tainted map<string>|Error {
+    public isolated function readAllProperties() returns @tainted map<string>|Error {
         return readAllPropertiesExtern(self);
     }
 
@@ -121,55 +121,55 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - If an error occurred while writing
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeReadableCharacterChannel(self);
     }
 }
 
-function initReadableCharacterChannel(ReadableCharacterChannel characterChannel, ReadableByteChannel byteChannel, 
+isolated function initReadableCharacterChannel(ReadableCharacterChannel characterChannel, ReadableByteChannel byteChannel,
                                       string charset) = @java:Method {
     name: "initCharacterChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readExtern(ReadableCharacterChannel characterChannel, @untainted int numberOfChars) returns @tainted string|
+isolated function readExtern(ReadableCharacterChannel characterChannel, @untainted int numberOfChars) returns @tainted string|
 Error = @java:Method {
     name: "read",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readAllLinesExtern(ReadableCharacterChannel characterChannel) returns @tainted string[]|Error = @java:Method {
+isolated function readAllLinesExtern(ReadableCharacterChannel characterChannel) returns @tainted string[]|Error = @java:Method {
     name: "readAllLines",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readAllAsStringExtern(ReadableCharacterChannel characterChannel) returns @tainted string|Error = @java:Method {
+isolated function readAllAsStringExtern(ReadableCharacterChannel characterChannel) returns @tainted string|Error = @java:Method {
     name: "readString",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readJsonExtern(ReadableCharacterChannel characterChannel) returns @tainted json|Error = @java:Method {
+isolated function readJsonExtern(ReadableCharacterChannel characterChannel) returns @tainted json|Error = @java:Method {
     name: "readJson",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readXmlExtern(ReadableCharacterChannel characterChannel) returns @tainted xml|Error = @java:Method {
+isolated function readXmlExtern(ReadableCharacterChannel characterChannel) returns @tainted xml|Error = @java:Method {
     name: "readXml",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readPropertyExtern(ReadableCharacterChannel characterChannel, string key, string defaultValue) returns @tainted string|
+isolated function readPropertyExtern(ReadableCharacterChannel characterChannel, string key, string defaultValue) returns @tainted string|
 Error = @java:Method {
     name: "readProperty",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function readAllPropertiesExtern(ReadableCharacterChannel characterChannel) returns @tainted map<string>|Error = @java:Method {
+isolated function readAllPropertiesExtern(ReadableCharacterChannel characterChannel) returns @tainted map<string>|Error = @java:Method {
     name: "readAllProperties",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function closeReadableCharacterChannel(ReadableCharacterChannel characterChannel) returns Error? = @java:Method {
+isolated function closeReadableCharacterChannel(ReadableCharacterChannel characterChannel) returns Error? = @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/readable_csv_channel.bal
+++ b/io-ballerina/readable_csv_channel.bal
@@ -25,7 +25,7 @@ public class ReadableCSVChannel {
     # + byteChannel - The CharacterChannel, which will represent the content in the CSV file
     # + fs - Field separator, which will separate between the records in the CSV file
     # + nHeaders - Number of headers, which should be skipped prior to reading records
-    public function init(ReadableCharacterChannel byteChannel, Separator fs = ",", int nHeaders = 0) {
+    public isolated function init(ReadableCharacterChannel byteChannel, Separator fs = ",", int nHeaders = 0) {
         if (fs == TAB) {
             self.dc = new ReadableTextRecordChannel(byteChannel, fmt = "TDF");
         } else if (fs == COLON) {
@@ -44,7 +44,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + nHeaders - The number of headers, which should be skipped
-    function skipHeaders(int nHeaders) {
+    public isolated function skipHeaders(int nHeaders) {
         int count = MINIMUM_HEADER_COUNT;
         while (count < nHeaders) {
             var result = self.getNext();
@@ -58,7 +58,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - True if there's a record
-    public function hasNext() returns boolean {
+    public isolated function hasNext() returns boolean {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
             return recordChannel.hasNext();
@@ -74,7 +74,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - List of fields in the CSV or else an `io:Error`
-    public function getNext() returns @tainted string[]|Error? {
+    public isolated function getNext() returns @tainted string[]|Error? {
         if (self.dc is ReadableTextRecordChannel) {
             var result = <ReadableTextRecordChannel>self.dc;
             return result.getNext();
@@ -88,7 +88,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - Either a stream of records(string[]) or else an `io:Error`
-    public function csvStream() returns stream<string[], Error>|Error {
+    public isolated function csvStream() returns stream<string[], Error>|Error {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
             CSVStream csvStream = new (recordChannel);
@@ -106,7 +106,7 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - `io:Error` if any error occurred
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         if (self.dc is ReadableTextRecordChannel) {
             var result = <ReadableTextRecordChannel>self.dc;
             return result.close();
@@ -123,13 +123,13 @@ public class ReadableCSVChannel {
     # + structType - The object in which the CSV records should be deserialized
     # + fieldNames - The names of the fields used as the (composite)key of the table
     # + return - Table, which represents the CSV records or else an `io:Error`
-    public function getTable(typedesc<record { }> structType, string[] fieldNames = []) returns @tainted table<record { }>|
+    public isolated function getTable(typedesc<record { }> structType, string[] fieldNames = []) returns @tainted table<record { }>|
     Error {
         return getTableExtern(self, structType, fieldNames);
     }
 }
 
-function getTableExtern(ReadableCSVChannel csvChannel, typedesc<record { }> structType, string[] fieldNames) returns @tainted table<record { }>|
+isolated function getTableExtern(ReadableCSVChannel csvChannel, typedesc<record { }> structType, string[] fieldNames) returns @tainted table<record { }>|
 Error = @java:Method {
     name: "getTable",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.GetTable"

--- a/io-ballerina/readable_data_channel.bal
+++ b/io-ballerina/readable_data_channel.bal
@@ -23,7 +23,7 @@ public class ReadableDataChannel {
     # 
     # + byteChannel - The channel, which would represent the source to read/write data
     # + bOrder - network byte order
-    public function init(ReadableByteChannel byteChannel, ByteOrder bOrder = "BE") {
+    public isolated function init(ReadableByteChannel byteChannel, ByteOrder bOrder = "BE") {
         // Remove temp once this got fixed #19842
         string temp = bOrder;
         initReadableDataChannel(self, byteChannel, temp);
@@ -35,7 +35,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
-    public function readInt16() returns int|Error {
+    public isolated function readInt16() returns int|Error {
         return readInt16Extern(self);
     }
 
@@ -45,7 +45,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
-    public function readInt32() returns int|Error {
+    public isolated function readInt32() returns int|Error {
         return readInt32Extern(self);
     }
 
@@ -55,7 +55,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the integer, which is read or else an `io:Error` if any error occurred
-    public function readInt64() returns int|Error {
+    public isolated function readInt64() returns int|Error {
         return readInt64Extern(self);
     }
 
@@ -65,7 +65,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the float which is read or else `io:Error` if any error occurred
-    public function readFloat32() returns float|Error {
+    public isolated function readFloat32() returns float|Error {
         return readFloat32Extern(self);
     }
 
@@ -75,7 +75,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the float which is read or else `io:Error` if any error occurred
-    public function readFloat64() returns float|Error {
+    public isolated function readFloat64() returns float|Error {
         return readFloat64Extern(self);
     }
 
@@ -85,7 +85,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - boolean value which is read or else `io:Error` if any error occurred
-    public function readBool() returns boolean|Error {
+    public isolated function readBool() returns boolean|Error {
         return readBoolExtern(self);
     }
 
@@ -97,7 +97,7 @@ public class ReadableDataChannel {
     # + nBytes - Specifies the number of bytes, which represents the string
     # + encoding - Specifies the char-set encoding of the string
     # + return - The value of the string or else `io:Error` if any error occurred
-    public function readString(int nBytes, string encoding) returns string|Error {
+    public isolated function readString(int nBytes, string encoding) returns string|Error {
         return readStringExtern(self, nBytes, encoding);
     }
 
@@ -107,7 +107,7 @@ public class ReadableDataChannel {
     # ```
     #
     # + return - The value of the integer which is read or else `io:Error` if any error occurred
-    public function readVarInt() returns int|Error {
+    public isolated function readVarInt() returns int|Error {
         return readVarIntExtern(self);
     }
 
@@ -117,57 +117,57 @@ public class ReadableDataChannel {
     # io:Error? err = dataChannel.close();
     # ```
     # + return - `()` if the channel is closed successfully or else an `io:Error` if any error occurred
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeReadableDataChannelExtern(self);
     }
 }
 
-function initReadableDataChannel(ReadableDataChannel dataChannel, ReadableByteChannel byteChannel, string bOrder) = @java:Method {
+isolated function initReadableDataChannel(ReadableDataChannel dataChannel, ReadableByteChannel byteChannel, string bOrder) = @java:Method {
     name: "initReadableDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readInt16Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
+isolated function readInt16Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt16",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readInt32Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
+isolated function readInt32Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt32",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readInt64Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
+isolated function readInt64Extern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readInt64",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readFloat32Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
+isolated function readFloat32Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
     name: "readFloat32",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readFloat64Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
+isolated function readFloat64Extern(ReadableDataChannel dataChannel) returns float|Error = @java:Method {
     name: "readFloat64",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readBoolExtern(ReadableDataChannel dataChannel) returns boolean|Error = @java:Method {
+isolated function readBoolExtern(ReadableDataChannel dataChannel) returns boolean|Error = @java:Method {
     name: "readBool",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readStringExtern(ReadableDataChannel dataChannel, int nBytes, string encoding) returns string|Error = @java:Method {
+isolated function readStringExtern(ReadableDataChannel dataChannel, int nBytes, string encoding) returns string|Error = @java:Method {
     name: "readString",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function readVarIntExtern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
+isolated function readVarIntExtern(ReadableDataChannel dataChannel) returns int|Error = @java:Method {
     name: "readVarInt",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function closeReadableDataChannelExtern(ReadableDataChannel dataChannel) returns Error? = @java:Method {
+isolated function closeReadableDataChannelExtern(ReadableDataChannel dataChannel) returns Error? = @java:Method {
     name: "closeDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/readable_record_channel.bal
+++ b/io-ballerina/readable_record_channel.bal
@@ -28,7 +28,7 @@ public class ReadableTextRecordChannel {
     # + charChannel - CharacterChannel which will point to the input/output resource
     # + fs - Field separator (this could be a regex)
     # + rs - Record separator (this could be a regex)
-    public function init(ReadableCharacterChannel charChannel, string fs = "", string rs = "", string fmt = "default") {
+    public isolated function init(ReadableCharacterChannel charChannel, string fs = "", string rs = "", string fmt = "default") {
         self.charChannel = charChannel;
         self.rs = rs;
         self.fs = fs;
@@ -41,7 +41,7 @@ public class ReadableTextRecordChannel {
     # ```
     #
     # + return - True if there's a record left to be read
-    public function hasNext() returns boolean {
+    public isolated function hasNext() returns boolean {
         return hasNextExtern(self);
     }
 
@@ -51,7 +51,7 @@ public class ReadableTextRecordChannel {
     # ```
     #
     # + return - Set of fields included in the record or else `io:Error`
-    public function getNext() returns @tainted string[]|Error {
+    public isolated function getNext() returns @tainted string[]|Error {
         return getNextExtern(self);
     }
 
@@ -62,28 +62,28 @@ public class ReadableTextRecordChannel {
     # ```
     #
     # + return - An `io:Error` if the record channel could not be closed properly
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeReadableTextRecordChannelExtern(self);
     }
 }
 
-function initReadableTextRecordChannel(ReadableTextRecordChannel textChannel, ReadableCharacterChannel charChannel, 
+isolated function initReadableTextRecordChannel(ReadableTextRecordChannel textChannel, ReadableCharacterChannel charChannel,
                                        string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
-function hasNextExtern(ReadableTextRecordChannel textChannel) returns boolean = @java:Method {
+isolated function hasNextExtern(ReadableTextRecordChannel textChannel) returns boolean = @java:Method {
     name: "hasNext",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
-function getNextExtern(ReadableTextRecordChannel textChannel) returns @tainted string[]|Error = @java:Method {
+isolated function getNextExtern(ReadableTextRecordChannel textChannel) returns @tainted string[]|Error = @java:Method {
     name: "getNext",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
-function closeReadableTextRecordChannelExtern(ReadableTextRecordChannel textChannel) returns Error? = @java:Method {
+isolated function closeReadableTextRecordChannelExtern(ReadableTextRecordChannel textChannel) returns Error? = @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;

--- a/io-ballerina/string_reader.bal
+++ b/io-ballerina/string_reader.bal
@@ -22,7 +22,7 @@ public class StringReader {
     #
     # + content - The content, which should be written
     # + encoding - Encoding of the characters of the content
-    public function init(string content, string encoding = "UTF-8") {
+    public isolated function init(string content, string encoding = "UTF-8") {
         byte[] contentBytes = content.toBytes();
         ReadableByteChannel byteChannel = checkpanic createReadableChannel(contentBytes);
         self.charChannel = new ReadableCharacterChannel(byteChannel, encoding);
@@ -35,7 +35,7 @@ public class StringReader {
     # ```
     #
     # + return - JSON or else `io:Error` if any error occurred
-    public function readJson() returns @tainted json|Error {
+    public isolated function readJson() returns @tainted json|Error {
         if (self.charChannel is ReadableCharacterChannel) {
             var result = <ReadableCharacterChannel>self.charChannel;
             return result.readJson();
@@ -50,7 +50,7 @@ public class StringReader {
     # ```
     #
     # + return - XML or else `io:Error` if any error occurred
-    public function readXml() returns @tainted xml|Error? {
+    public isolated function readXml() returns @tainted xml|Error? {
         if (self.charChannel is ReadableCharacterChannel) {
             var result = <ReadableCharacterChannel>self.charChannel;
             return result.readXml();
@@ -66,7 +66,7 @@ public class StringReader {
     #
     # + nCharacters - Number of characters to be read
     # + return - String or else `io:Error` if any error occurred
-    public function readChar(int nCharacters) returns @tainted string|Error? {
+    public isolated function readChar(int nCharacters) returns @tainted string|Error? {
         if (self.charChannel is ReadableCharacterChannel) {
             var result = <ReadableCharacterChannel>self.charChannel;
             return result.read(nCharacters);
@@ -80,7 +80,7 @@ public class StringReader {
     # ```
     #
     # + return - An `io:Error` if could not close the channel or else `()`
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         if (self.charChannel is ReadableCharacterChannel) {
             var result = <ReadableCharacterChannel>self.charChannel;
             return result.close();

--- a/io-ballerina/writable_byte_channel.bal
+++ b/io-ballerina/writable_byte_channel.bal
@@ -23,7 +23,7 @@ import ballerina/jballerina.java;
 public class WritableByteChannel {
 
     # Adding default init function to prevent object getting initialized from the user code.
-    function init() {
+    isolated function init() {
     }
 
     # Sinks bytes from a given input/output resource.
@@ -36,7 +36,7 @@ public class WritableByteChannel {
     # + content - Block of bytes to be written
     # + offset - Offset of the provided content, which needs to be kept when writing bytes
     # + return - Number of bytes written or else `io:Error`
-    public function write(byte[] content, int offset) returns int|Error {
+    public isolated function write(byte[] content, int offset) returns int|Error {
         return byteWriteExtern(self, content, offset);
     }
 
@@ -47,17 +47,17 @@ public class WritableByteChannel {
     # ```
     #
     # + return - `io:Error` or else `()`
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeWritableByteChannelExtern(self);
     }
 }
 
-function byteWriteExtern(WritableByteChannel byteChannel, byte[] content, int offset) returns int|Error = @java:Method {
+isolated function byteWriteExtern(WritableByteChannel byteChannel, byte[] content, int offset) returns int|Error = @java:Method {
     name: "write",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
 
-function closeWritableByteChannelExtern(WritableByteChannel byteChannel) returns Error? = @java:Method {
+isolated function closeWritableByteChannelExtern(WritableByteChannel byteChannel) returns Error? = @java:Method {
     name: "closeByteChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;

--- a/io-ballerina/writable_character_channel.bal
+++ b/io-ballerina/writable_character_channel.bal
@@ -26,7 +26,7 @@ public class WritableCharacterChannel {
     # 
     # + bChannel - The `WritableByteChannel`, which would be used to write the characters
     # + charset - The character set, which would be used to encode the given bytes to characters
-    public function init(WritableByteChannel bChannel, string charset) {
+    public isolated function init(WritableByteChannel bChannel, string charset) {
         self.bChannel = bChannel;
         self.charset = charset;
         initWritableCharacterChannel(self, bChannel, charset);
@@ -40,7 +40,7 @@ public class WritableCharacterChannel {
     # + content - Content to be written
     # + startOffset - Number of characters to be offset when writing the content
     # + return - Content length that written or else `io:Error`
-    public function write(string content, int startOffset) returns int|Error {
+    public isolated function write(string content, int startOffset) returns int|Error {
         return writeExtern(self, content, startOffset);
     }
 
@@ -51,7 +51,7 @@ public class WritableCharacterChannel {
     #
     # + content - Content to be written
     # + return - Returns null if the writing was successful or an `io:Error`
-    public function writeLine(string content) returns Error? {
+    public isolated function writeLine(string content) returns Error? {
         string lineContent = content + NEW_LINE;
         var result = writeExtern(self, lineContent, 0);
         if (result is Error) {
@@ -68,7 +68,7 @@ public class WritableCharacterChannel {
     #
     # + content - The JSON to be written
     # + return - Returns null if the writing was successful or an `io:Error`
-    public function writeJson(json content) returns Error? {
+    public isolated function writeJson(json content) returns Error? {
         return writeJsonExtern(self, content);
     }
 
@@ -80,7 +80,7 @@ public class WritableCharacterChannel {
     # + content - The XML to be written
     # + xmlDoctype - Optional argument to specify the XML DOCTYPE configurations
     # + return - `()` or else `io:Error` if any error occurred
-    public function writeXml(xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
+    public isolated function writeXml(xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
         string doctype = "";
         if (xmlDoctype != ()) {
             doctype = populateDoctype(content, <XmlDoctype>xmlDoctype);
@@ -95,7 +95,7 @@ public class WritableCharacterChannel {
     # + properties - The map<string> that contains keys and values
     # + comment - Comment describing the property list
     # + return - `()` or else `io:Error` if any error occurred
-    public function writeProperties(map<string> properties, string comment) returns Error? {
+    public isolated function writeProperties(map<string> properties, string comment) returns Error? {
         return writePropertiesExtern(self, properties, comment);
     }
 
@@ -106,12 +106,12 @@ public class WritableCharacterChannel {
     # ```
     #
     # + return - `()` or else an `io:Error` if any error occurred
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeWritableCharacterChannel(self);
     }
 }
 
-function populateDoctype(xml content, XmlDoctype doctype) returns string {
+isolated function populateDoctype(xml content, XmlDoctype doctype) returns string {
     // Generate <!DOCTYPE rootElementName PUBLIC|SYSTEM PublicIdentifier SystemIdentifier internalSubset>
     string doctypeElement = "";
     string startElement = "<!DOCTYPE";
@@ -136,34 +136,34 @@ function populateDoctype(xml content, XmlDoctype doctype) returns string {
     return doctypeElement;
 }
 
-function initWritableCharacterChannel(WritableCharacterChannel characterChannel, WritableByteChannel byteChannel, 
+isolated function initWritableCharacterChannel(WritableCharacterChannel characterChannel, WritableByteChannel byteChannel,
                                       string charset) = @java:Method {
     name: "initCharacterChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function writeExtern(WritableCharacterChannel characterChannel, string content, int startOffset) returns int|Error = @java:Method {
+isolated function writeExtern(WritableCharacterChannel characterChannel, string content, int startOffset) returns int|Error = @java:Method {
     name: "write",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function writeJsonExtern(WritableCharacterChannel characterChannel, json content) returns Error? = @java:Method {
+isolated function writeJsonExtern(WritableCharacterChannel characterChannel, json content) returns Error? = @java:Method {
     name: "writeJson",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function writeXmlExtern(WritableCharacterChannel characterChannel, xml content, string doctype) returns Error? = @java:Method {
+isolated function writeXmlExtern(WritableCharacterChannel characterChannel, xml content, string doctype) returns Error? = @java:Method {
     name: "writeXml",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties, string comment) returns 
+isolated function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties, string comment) returns
 Error? = @java:Method {
     name: "writeProperties",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-function closeWritableCharacterChannel(WritableCharacterChannel characterChannel) returns Error? = @java:Method {
+isolated function closeWritableCharacterChannel(WritableCharacterChannel characterChannel) returns Error? = @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/writable_csv_channel.bal
+++ b/io-ballerina/writable_csv_channel.bal
@@ -31,7 +31,7 @@ public class WritableCSVChannel {
     # 
     # + CharacterChannel - The `CharacterChannel`, which will represent the content in the CSV file
     # + fs - Field separator, which will separate the records in the CSV
-    public function init(WritableCharacterChannel characterChannel, Separator fs = ",") {
+    public isolated function init(WritableCharacterChannel characterChannel, Separator fs = ",") {
         if (fs == TAB) {
             self.dc = new WritableTextRecordChannel(characterChannel, fmt = "TDF");
         } else if (fs == COLON) {
@@ -50,7 +50,7 @@ public class WritableCSVChannel {
     #
     # + csvRecord - A record to be written to the channel
     # + return - An `io:Error` if the record could not be written properly
-    public function write(string[] csvRecord) returns Error? {
+    public isolated function write(string[] csvRecord) returns Error? {
         if (self.dc is WritableTextRecordChannel) {
             var result = <WritableTextRecordChannel>self.dc;
             return result.write(csvRecord);
@@ -65,7 +65,7 @@ public class WritableCSVChannel {
     # ```
     #
     # + return - `()` or else `io:Error` if any error occurred
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         if (self.dc is WritableTextRecordChannel) {
             var result = <WritableTextRecordChannel>self.dc;
             return result.close();

--- a/io-ballerina/writable_data_channel.bal
+++ b/io-ballerina/writable_data_channel.bal
@@ -36,7 +36,7 @@ public class WritableDataChannel {
     #
     # + byteChannel - channel which would represent the source to read/write data
     # + bOrder - network byte order
-    public function init(WritableByteChannel byteChannel, ByteOrder bOrder = "BE") {
+    public isolated function init(WritableByteChannel byteChannel, ByteOrder bOrder = "BE") {
         // Remove temp once this got fixed #19842
         string temp = bOrder;
         initWritableDataChannel(self, byteChannel, temp);
@@ -49,7 +49,7 @@ public class WritableDataChannel {
     #
     # + value - The integer, which will be written
     # + return - `()` if the content is written successfully or else an `io:Error` if any error occurred
-    public function writeInt16(int value) returns Error? {
+    public isolated function writeInt16(int value) returns Error? {
         return writeInt16Extern(self, value);
     }
 
@@ -60,7 +60,7 @@ public class WritableDataChannel {
     #
     # + value - The integer, which will be written
     # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
-    public function writeInt32(int value) returns Error? {
+    public isolated function writeInt32(int value) returns Error? {
         return writeInt32Extern(self, value);
     }
 
@@ -71,7 +71,7 @@ public class WritableDataChannel {
     #
     # + value - The integer, which will be written
     # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
-    public function writeInt64(int value) returns Error? {
+    public isolated function writeInt64(int value) returns Error? {
         return writeInt64Extern(self, value);
     }
 
@@ -82,7 +82,7 @@ public class WritableDataChannel {
     #
     # + value - The float, which will be written
     # + return - `()` if the float is written successfully or else `io:Error` if any error occurred
-    public function writeFloat32(float value) returns Error? {
+    public isolated function writeFloat32(float value) returns Error? {
         return writeFloat32Extern(self, value);
     }
 
@@ -93,7 +93,7 @@ public class WritableDataChannel {
     #
     # + value - The float, which will be written
     # + return - `()` if the float is written successfully or else `io:Error` if any error occurred
-    public function writeFloat64(float value) returns Error? {
+    public isolated function writeFloat64(float value) returns Error? {
         return writeFloat64Extern(self, value);
     }
 
@@ -104,7 +104,7 @@ public class WritableDataChannel {
     #
     # + value - The boolean, which will be written
     # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
-    public function writeBool(boolean value) returns Error? {
+    public isolated function writeBool(boolean value) returns Error? {
         return writeBoolExtern(self, value);
     }
 
@@ -116,7 +116,7 @@ public class WritableDataChannel {
     # + value - The value, which should be written
     # + encoding - The encoding, which will represent the value string
     # + return - `()` if the content is written successfully or else `io:Error` if any error occurred
-    public function writeString(string value, string encoding) returns Error? {
+    public isolated function writeString(string value, string encoding) returns Error? {
         return writeStringExtern(self, value, encoding);
     }
 
@@ -127,7 +127,7 @@ public class WritableDataChannel {
     #
     # + value - The int, which will be written
     # + return - The value of the integer, which is written or else `io:Error` if any error occurred
-    public function writeVarInt(int value) returns Error? {
+    public isolated function writeVarInt(int value) returns Error? {
         return writeVarIntExtern(self, value);
     }
 
@@ -138,57 +138,57 @@ public class WritableDataChannel {
     # ```
     #
     # + return - `()` if the channel is closed successfully or else `io:Error` if any error occurred
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeWritableDataChannelExtern(self);
     }
 }
 
-function initWritableDataChannel(WritableDataChannel dataChannel, WritableByteChannel byteChannel, string bOrder) = @java:Method {
+isolated function initWritableDataChannel(WritableDataChannel dataChannel, WritableByteChannel byteChannel, string bOrder) = @java:Method {
     name: "initWritableDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeInt16Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
+isolated function writeInt16Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt16",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeInt32Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
+isolated function writeInt32Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt32",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeInt64Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
+isolated function writeInt64Extern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeInt64",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeFloat32Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
+isolated function writeFloat32Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
     name: "writeFloat32",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeFloat64Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
+isolated function writeFloat64Extern(WritableDataChannel dataChannel, float value) returns Error? = @java:Method {
     name: "writeFloat64",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeBoolExtern(WritableDataChannel dataChannel, boolean value) returns Error? = @java:Method {
+isolated function writeBoolExtern(WritableDataChannel dataChannel, boolean value) returns Error? = @java:Method {
     name: "writeBool",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeStringExtern(WritableDataChannel dataChannel, string value, string encoding) returns Error? = @java:Method {
+isolated function writeStringExtern(WritableDataChannel dataChannel, string value, string encoding) returns Error? = @java:Method {
     name: "writeString",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function writeVarIntExtern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
+isolated function writeVarIntExtern(WritableDataChannel dataChannel, int value) returns Error? = @java:Method {
     name: "writeVarInt",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;
 
-function closeWritableDataChannelExtern(WritableDataChannel dataChannel) returns Error? = @java:Method {
+isolated function closeWritableDataChannelExtern(WritableDataChannel dataChannel) returns Error? = @java:Method {
     name: "closeDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/writable_record_channel.bal
+++ b/io-ballerina/writable_record_channel.bal
@@ -30,7 +30,7 @@ public class WritableTextRecordChannel {
     #         "DEFAULT" (the format specified by the CSVChannel), 
     #         "CSV" (Field separator would be "," and record separator would be a new line) or else
     #         "TDF" (Field separator will be a tab and record separator will be a new line). 
-    public function init(WritableCharacterChannel characterChannel, string fs = "", string rs = "", string fmt = 
+    public isolated function init(WritableCharacterChannel characterChannel, string fs = "", string rs = "", string fmt =
                          "default") {
         self.characterChannel = characterChannel;
         self.fs = fs;
@@ -45,7 +45,7 @@ public class WritableTextRecordChannel {
     #
     # + textRecord - List of fields to be written
     # + return - An `io:Error` if the records could not be written properly or else `()`
-    public function write(string[] textRecord) returns Error? {
+    public isolated function write(string[] textRecord) returns Error? {
         return writeRecordExtern(self, textRecord);
     }
 
@@ -56,23 +56,23 @@ public class WritableTextRecordChannel {
     # ```
     #
     # + return - An `io:Error` if the record channel could not be closed properly or else `()`
-    public function close() returns Error? {
+    public isolated function close() returns Error? {
         return closeWritableTextRecordChannelExtern(self);
     }
 }
 
-function initWritableTextRecordChannel(WritableTextRecordChannel textChannel, WritableCharacterChannel charChannel, 
+isolated function initWritableTextRecordChannel(WritableTextRecordChannel textChannel, WritableCharacterChannel charChannel,
                                        string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
-function writeRecordExtern(WritableTextRecordChannel textChannel, string[] textRecord) returns Error? = @java:Method {
+isolated function writeRecordExtern(WritableTextRecordChannel textChannel, string[] textRecord) returns Error? = @java:Method {
     name: "write",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;
 
-function closeWritableTextRecordChannelExtern(WritableTextRecordChannel textChannel) returns Error? = @java:Method {
+isolated function closeWritableTextRecordChannelExtern(WritableTextRecordChannel textChannel) returns Error? = @java:Method {
     name: "close",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;


### PR DESCRIPTION
## Purpose
Fix https://github.com/ballerina-platform/ballerina-standard-library/issues/1053

## Approach
- Make I/O APIs isolated
- Change stream `forEach` with a `while` loop because the function inside `forEach` is accession `channels` outside the loop

## Related PRs
https://github.com/ballerina-platform/module-ballerina-io/pull/8

## Test environment
- macOS
- Java 11
- Swan Lake 3 
 