### PR TITLE
Improve the I/O print operations to support string templates

### DIFF
--- a/io-ballerina/channel_byte_io.bal
+++ b/io-ballerina/channel_byte_io.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/lang.'value;
 
 isolated function channelReadBytes(ReadableChannel readableChannel) returns @tainted readonly & byte[]|Error {
@@ -22,18 +21,19 @@ isolated function channelReadBytes(ReadableChannel readableChannel) returns @tai
         var closeResult = readableChannel.close();
         return result;
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel but found a " +
-        'value:toString(typeof readableChannel));
+        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel but found a " + 'value:toString(typeof 
+        readableChannel));
         return e;
     }
 }
 
-isolated function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize=4096) returns @tainted stream<Block, Error>|Error {
+isolated function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize = 4096) returns @tainted stream<
+Block, Error>|Error {
     if (readableChannel is ReadableByteChannel) {
         return readableChannel.blockStream(blockSize);
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel but found a " +
-        'value:toString(typeof readableChannel));
+        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel but found a " + 'value:toString(typeof 
+        readableChannel));
         return e;
     }
 }
@@ -46,16 +46,17 @@ isolated function channelWriteBytes(WritableChannel writableChannel, byte[] cont
             return closeResult;
         }
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected WritableByteChannel but found a " +
-        'value:toString(typeof writableChannel));
+        TypeMismatchError e = error TypeMismatchError("Expected WritableByteChannel but found a " + 'value:toString(typeof 
+        writableChannel));
         return e;
     }
 }
 
-isolated function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[], Error> byteStream) returns Error? {
+isolated function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[], Error> byteStream) returns 
+Error? {
     if (writableChannel is WritableByteChannel) {
         record {| byte[] value; |}|Error? block = byteStream.next();
-        while(block is record {| byte[] value; |}) {
+        while (block is record {| byte[] value; |}) {
             var writeResult = writableChannel.write(block.value, 0);
             block = byteStream.next();
         }
@@ -67,7 +68,7 @@ isolated function channelWriteBlocksFromStream(WritableChannel writableChannel, 
             return closeResult;
         }
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected WritableByteChannel but found a " + 'value:toString(typeof
+        TypeMismatchError e = error TypeMismatchError("Expected WritableByteChannel but found a " + 'value:toString(typeof 
         writableChannel));
         return e;
     }

--- a/io-ballerina/channel_csv_io.bal
+++ b/io-ballerina/channel_csv_io.bal
@@ -13,10 +13,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/lang.'value;
 
-isolated function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) returns @tainted string[][]|Error {
+isolated function channelReadCsv(ReadableChannel readableChannel, int skipHeaders = 0) returns @tainted string[][]|
+Error {
     ReadableCSVChannel csvChannel = check getReadableCSVChannel(readableChannel, skipHeaders);
     string[][] results = [];
     int i = 0;
@@ -35,7 +35,8 @@ isolated function channelReadCsv(ReadableChannel readableChannel, int skipHeader
     return results;
 }
 
-isolated function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[], Error>|Error {
+isolated function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[], Error>|
+Error {
     return (check getReadableCSVChannel(readableChannel, 0)).csvStream();
 }
 
@@ -51,10 +52,11 @@ isolated function channelWriteCsv(WritableChannel writableChannel, string[][] co
     check csvChannel.close();
 }
 
-isolated function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[], Error> csvStream) returns Error? {
+isolated function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[], Error> csvStream) returns 
+Error? {
     WritableCSVChannel csvChannel = check getWritableCSVChannel(writableChannel);
     record {| string[] value; |}|Error? csvRecord = csvStream.next();
-    while(csvRecord is record {| string[] value; |}) {
+    while (csvRecord is record {| string[] value; |}) {
         var writeResult = csvChannel.write(csvRecord.value);
         csvRecord = csvStream.next();
     }
@@ -67,7 +69,8 @@ isolated function channelWriteCsvFromStream(WritableChannel writableChannel, str
     }
 }
 
-isolated function getReadableCSVChannel(ReadableChannel readableChannel, int skipHeaders) returns ReadableCSVChannel|Error {
+isolated function getReadableCSVChannel(ReadableChannel readableChannel, int skipHeaders) returns ReadableCSVChannel|
+Error {
     ReadableCSVChannel readableCSVChannel;
 
     if (readableChannel is ReadableByteChannel) {
@@ -78,9 +81,8 @@ isolated function getReadableCSVChannel(ReadableChannel readableChannel, int ski
     } else if (readableChannel is ReadableCSVChannel) {
         readableCSVChannel = readableChannel;
     } else {
-        TypeMismatchError e = error TypeMismatchError(
-        "Expected ReadableByteChannel/ReadableCharacterChannel/ReadableCSVChannel but found a " + 'value:toString(typeof 
-        readableChannel));
+        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel/ReadableCharacterChannel/ReadableCSVChannel but found a " + 
+        'value:toString(typeof readableChannel));
         return e;
     }
     return readableCSVChannel;
@@ -97,9 +99,8 @@ isolated function getWritableCSVChannel(WritableChannel writableChannel) returns
     } else if (writableChannel is WritableCSVChannel) {
         writableCSVChannel = writableChannel;
     } else {
-        TypeMismatchError e = error TypeMismatchError(
-        "Expected WritableByteChannel/WritableCharacterChannel/WritableCSVChannel but found a " + 'value:toString(typeof 
-        writableChannel));
+        TypeMismatchError e = error TypeMismatchError("Expected WritableByteChannel/WritableCharacterChannel/WritableCSVChannel but found a " + 
+        'value:toString(typeof writableChannel));
         return e;
     }
     return writableCSVChannel;

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -17,154 +17,111 @@
 import ballerina/lang.'value;
 
 isolated function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
-    var characterChannel = getReadableCharacterChannel(readableChannel);
-    if (characterChannel is ReadableCharacterChannel) {
-        var result = characterChannel.readString();
-        var closeResult = characterChannel.close();
-        return result;
-    } else {
-        return characterChannel;
-    }
+    ReadableCharacterChannel characterChannel = check getReadableCharacterChannel(readableChannel);
+    var result = characterChannel.readString();
+    var closeResult = characterChannel.close();
+    return result;
 }
 
 isolated function channelReadLines(ReadableChannel readableChannel) returns @tainted string[]|Error {
-    var characterChannel = getReadableCharacterChannel(readableChannel);
-    if (characterChannel is ReadableCharacterChannel) {
-        var result = characterChannel.readAllLines();
-        var closeResult = characterChannel.close();
-        return result;
-    } else {
-        return characterChannel;
-    }
+    ReadableCharacterChannel characterChannel = check getReadableCharacterChannel(readableChannel);
+    var result = characterChannel.readAllLines();
+    var closeResult = characterChannel.close();
+    return result;
 }
 
 isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
-    var characterChannel = getReadableCharacterChannel(readableChannel);
-    if (characterChannel is ReadableCharacterChannel) {
-        return characterChannel.lineStream();
-    } else {
-        return characterChannel;
-    }
+    return (check getReadableCharacterChannel(readableChannel)).lineStream();
 }
 
 isolated function channelReadJson(ReadableChannel readableChannel) returns @tainted json|Error {
-    var characterChannel = getReadableCharacterChannel(readableChannel);
-    if (characterChannel is ReadableCharacterChannel) {
-        var result = characterChannel.readJson();
-        var closeResult = characterChannel.close();
-        return result;
-    } else {
-        return characterChannel;
-    }
+    ReadableCharacterChannel characterChannel = check getReadableCharacterChannel(readableChannel);
+    var result = characterChannel.readJson();
+    var closeResult = characterChannel.close();
+    return result;
 }
 
 isolated function channelReadXml(ReadableChannel readableChannel) returns @tainted xml|Error {
-    var characterChannel = getReadableCharacterChannel(readableChannel);
-    if (characterChannel is ReadableCharacterChannel) {
-        var result = characterChannel.readXml();
-        var closeResult = characterChannel.close();
-        return result;
-    } else {
-        return characterChannel;
-    }
+    ReadableCharacterChannel characterChannel = check getReadableCharacterChannel(readableChannel);
+    var result = characterChannel.readXml();
+    var closeResult = characterChannel.close();
+    return result;
 }
 
 isolated function channelWriteString(WritableChannel writableChannel, string content) returns Error? {
-    var characterChannel = getWritableCharacterChannel(writableChannel);
-    if (characterChannel is WritableCharacterChannel) {
-        var writeResult = characterChannel.write(content, 0);
-        if (writeResult is Error) {
-            return writeResult;
-        }
-        var closeResult = characterChannel.close();
-        if (closeResult is Error) {
-            return closeResult;
-        }
-        return ();
-    } else {
-        return characterChannel;
+    WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
+    var writeResult = characterChannel.write(content, 0);
+    var closeResult = characterChannel.close();
+    if (writeResult is Error) {
+        return writeResult;
+    }
+    if (closeResult is Error) {
+        return closeResult;
     }
 }
 
 isolated function channelWriteLines(WritableChannel writableChannel, string[] content) returns Error? {
-    var characterChannel = getWritableCharacterChannel(writableChannel);
-    if (characterChannel is WritableCharacterChannel) {
-        string writeContent = "";
-        foreach string line in content {
-            writeContent = writeContent + line + NEW_LINE;
-        }
-        var writeResult = characterChannel.write(writeContent, 0);
-        if (writeResult is Error) {
-            return writeResult;
-        }
-        var closeResult = characterChannel.close();
-        if (closeResult is Error) {
-            return closeResult;
-        }
-        return ();
-    } else {
-        return characterChannel;
+    WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
+    string writeContent = "";
+    foreach string line in content {
+        writeContent = writeContent + line + NEW_LINE;
+    }
+    var writeResult = characterChannel.write(writeContent, 0);
+    var closeResult = characterChannel.close();
+    if (writeResult is Error) {
+        return writeResult;
+    }
+    if (closeResult is Error) {
+        return closeResult;
     }
 }
 
 isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns Error? {
-    var characterChannel = getWritableCharacterChannel(writableChannel);
-    if (characterChannel is WritableCharacterChannel) {
-        record {| string value; |}|Error? line = lineStream.next();
-        while(line is record {| string value; |}) {
-            var writeResult = characterChannel.writeLine(line.value);
-            line = lineStream.next();
-        }
-        var closeResult = characterChannel.close();
-        if (line is Error) {
-            return line;
-        }
-        if (closeResult is Error) {
-            return closeResult;
-        }
-        return ();
-    } else {
-        return characterChannel;
+    WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
+    record {| string value; |}|Error? line = lineStream.next();
+    while(line is record {| string value; |}) {
+        var writeResult = characterChannel.writeLine(line.value);
+        line = lineStream.next();
     }
+    var closeResult = characterChannel.close();
+    if (line is Error) {
+        return line;
+    }
+    if (closeResult is Error) {
+        return closeResult;
+    }
+    return ();
 }
 
 isolated function channelWriteJson(WritableChannel writableChannel, json content) returns @tainted Error? {
-    var characterChannel = getWritableCharacterChannel(writableChannel);
-    if (characterChannel is WritableCharacterChannel) {
-        var writeResult = characterChannel.writeJson(content);
-        if (writeResult is Error) {
-            return writeResult;
-        }
-        var closeResult = characterChannel.close();
-        if (closeResult is Error) {
-            return closeResult;
-        }
-        return ();
-    } else {
-        return characterChannel;
+    WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
+    var writeResult = characterChannel.writeJson(content);
+    var closeResult = characterChannel.close();
+    if (writeResult is Error) {
+        return writeResult;
     }
+    if (closeResult is Error) {
+        return closeResult;
+    }
+    return ();
 }
 
 isolated function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
-    var characterChannel = getWritableCharacterChannel(writableChannel);
-    if (characterChannel is WritableCharacterChannel) {
-        Error? writeResult = ();
-        if (xmlDoctype != ()) {
-            writeResult = characterChannel.writeXml(content, <XmlDoctype>xmlDoctype);
-        } else {
-            writeResult = characterChannel.writeXml(content);
-        }
-        if (writeResult is Error) {
-            return writeResult;
-        }
-        var closeResult = characterChannel.close();
-        if (closeResult is Error) {
-            return closeResult;
-        }
-        return ();
+    WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
+    Error? writeResult = ();
+    if (xmlDoctype != ()) {
+        writeResult = characterChannel.writeXml(content, <XmlDoctype>xmlDoctype);
     } else {
-        return characterChannel;
+        writeResult = characterChannel.writeXml(content);
     }
+    var closeResult = characterChannel.close();
+    if (writeResult is Error) {
+        return writeResult;
+    }
+    if (closeResult is Error) {
+        return closeResult;
+    }
+    return ();
 }
 
 isolated function getReadableCharacterChannel(ReadableChannel readableChannel) returns ReadableCharacterChannel|Error {

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/lang.'value;
 
 isolated function channelReadString(ReadableChannel readableChannel) returns @tainted string|Error {
@@ -30,7 +29,8 @@ isolated function channelReadLines(ReadableChannel readableChannel) returns @tai
     return result;
 }
 
-isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|Error {
+isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|
+Error {
     return (check getReadableCharacterChannel(readableChannel)).lineStream();
 }
 
@@ -76,10 +76,11 @@ isolated function channelWriteLines(WritableChannel writableChannel, string[] co
     }
 }
 
-isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns Error? {
+isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns 
+Error? {
     WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
     record {| string value; |}|Error? line = lineStream.next();
-    while(line is record {| string value; |}) {
+    while (line is record {| string value; |}) {
         var writeResult = characterChannel.writeLine(line.value);
         line = lineStream.next();
     }
@@ -106,7 +107,8 @@ isolated function channelWriteJson(WritableChannel writableChannel, json content
     return ();
 }
 
-isolated function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns Error? {
+isolated function channelWriteXml(WritableChannel writableChannel, xml content, XmlDoctype? xmlDoctype = ()) returns 
+Error? {
     WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
     Error? writeResult = ();
     if (xmlDoctype != ()) {
@@ -131,7 +133,7 @@ isolated function getReadableCharacterChannel(ReadableChannel readableChannel) r
     } else if (readableChannel is ReadableCharacterChannel) {
         readableCharacterChannel = readableChannel;
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel/ReadableCharacterChannel but found a " +
+        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel/ReadableCharacterChannel but found a " + 
         'value:toString(typeof readableChannel));
         return e;
     }
@@ -145,7 +147,7 @@ isolated function getWritableCharacterChannel(WritableChannel writableChannel) r
     } else if (writableChannel is WritableCharacterChannel) {
         writableCharacterChannel = writableChannel;
     } else {
-        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel/ReadableCharacterChannel but found a " +
+        TypeMismatchError e = error TypeMismatchError("Expected ReadableByteChannel/ReadableCharacterChannel but found a " + 
         'value:toString(typeof writableChannel));
         return e;
     }

--- a/io-ballerina/file_byte_io.bal
+++ b/io-ballerina/file_byte_io.bal
@@ -21,12 +21,7 @@
 # + path - The path of the file
 # + return - Either a read only byte array or `io:Error`
 public isolated function fileReadBytes(@untainted string path) returns @tainted readonly & byte[]|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadBytes(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadBytes(check openReadableFile(path));
 }
 
 # Read the entire file content as a stream of blocks.
@@ -37,12 +32,7 @@ public isolated function fileReadBytes(@untainted string path) returns @tainted 
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
 public isolated function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block, Error>|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadBlocksAsStream(byteChannel, blockSize);
-    } else {
-        return byteChannel;
-    }
+    return channelReadBlocksAsStream(check openReadableFile(path), blockSize);
 }
 
 # Write a set of bytes to a file.
@@ -56,12 +46,7 @@ public isolated function fileReadBlocksAsStream(string path, int blockSize=4096)
 # + return - `io:Error` or else `()`
 public isolated function fileWriteBytes(@untainted string path, byte[] content,
                             FileWriteOption option = OVERWRITE) returns Error? {
-    var byteChannel = openWritableFile(path, option);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteBytes(byteChannel, content);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteBytes(check openWritableFile(path, option), content);
 }
 
 # Write a byte stream to a file.
@@ -76,11 +61,5 @@ public isolated function fileWriteBytes(@untainted string path, byte[] content,
 # + return - `io:Error` or else `()`
 public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream,
                         FileWriteOption option = OVERWRITE) returns Error? {
-
-    var byteChannel = openWritableFile(path, option);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteBlocksFromStream(byteChannel, byteStream);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteBlocksFromStream(check openWritableFile(path, option), byteStream);
 }

--- a/io-ballerina/file_byte_io.bal
+++ b/io-ballerina/file_byte_io.bal
@@ -31,7 +31,8 @@ public isolated function fileReadBytes(@untainted string path) returns @tainted 
 # + path - The path of the file
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
-public isolated function fileReadBlocksAsStream(string path, int blockSize=4096) returns @tainted stream<Block, Error>|Error {
+public isolated function fileReadBlocksAsStream(string path, int blockSize = 4096) returns @tainted stream<Block, Error>|
+Error {
     return channelReadBlocksAsStream(check openReadableFile(path), blockSize);
 }
 
@@ -44,8 +45,8 @@ public isolated function fileReadBlocksAsStream(string path, int blockSize=4096)
 # + content - Byte content to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - `io:Error` or else `()`
-public isolated function fileWriteBytes(@untainted string path, byte[] content,
-                            FileWriteOption option = OVERWRITE) returns Error? {
+public isolated function fileWriteBytes(@untainted string path, byte[] content, FileWriteOption option = OVERWRITE) returns 
+Error? {
     return channelWriteBytes(check openWritableFile(path, option), content);
 }
 
@@ -59,7 +60,7 @@ public isolated function fileWriteBytes(@untainted string path, byte[] content,
 # + byteStream - Byte stream to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - `io:Error` or else `()`
-public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream,
-                        FileWriteOption option = OVERWRITE) returns Error? {
+public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream, 
+                                                   FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteBlocksFromStream(check openWritableFile(path, option), byteStream);
 }

--- a/io-ballerina/file_csv_io.bal
+++ b/io-ballerina/file_csv_io.bal
@@ -22,13 +22,7 @@
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
 # + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
 public isolated function fileReadCsv(@untainted string path, int skipHeaders = 0) returns @tainted string[][]|Error {
-
-    var csvChannel = openReadableCsvFile(path, COMMA, DEFAULT_ENCODING, skipHeaders);
-    if (csvChannel is ReadableCSVChannel) {
-        return channelReadCsv(csvChannel);
-    } else {
-        return csvChannel;
-    }
+    return channelReadCsv(check openReadableCsvFile(path, COMMA, DEFAULT_ENCODING, skipHeaders));
 }
 
 # Read file content as a CSV.
@@ -38,12 +32,7 @@ public isolated function fileReadCsv(@untainted string path, int skipHeaders = 0
 # + path - The CSV file path
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
 public isolated function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error>|Error {
-    var csvChannel = openReadableCsvFile(path);
-    if (csvChannel is ReadableCSVChannel) {
-        return csvChannel.csvStream();
-    } else {
-        return csvChannel;
-    }
+    return (check openReadableCsvFile(path)).csvStream();
 }
 
 # Write CSV content to a file.
@@ -57,12 +46,7 @@ public isolated function fileReadCsvAsStream(@untainted string path) returns @ta
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
 public isolated function fileWriteCsv(@untainted string path, string[][] content,
                         FileWriteOption option = OVERWRITE) returns Error? {
-    var csvChannel = openWritableCsvFile(path, option=option);
-    if (csvChannel is WritableCSVChannel) {
-        return channelWriteCsv(csvChannel, content);
-    } else {
-        return csvChannel;
-    }
+    return channelWriteCsv(check openWritableCsvFile(path, option=option), content);
 }
 
 # Write CSV record stream to a file.
@@ -77,10 +61,5 @@ public isolated function fileWriteCsv(@untainted string path, string[][] content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
 public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content,
                     FileWriteOption option = OVERWRITE) returns Error? {
-    var csvChannel = openWritableCsvFile(path, option=option);
-    if (csvChannel is WritableCSVChannel) {
-        return channelWriteCsvFromStream(csvChannel, content);
-    } else {
-        return csvChannel;
-    }
+    return channelWriteCsvFromStream(check openWritableCsvFile(path, option=option), content);
 }

--- a/io-ballerina/file_csv_io.bal
+++ b/io-ballerina/file_csv_io.bal
@@ -44,9 +44,9 @@ public isolated function fileReadCsvAsStream(@untainted string path) returns @ta
 # + content - CSV content as an array of string arrays
 # + option - To indicate whether to overwrite or append the given content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public isolated function fileWriteCsv(@untainted string path, string[][] content,
-                        FileWriteOption option = OVERWRITE) returns Error? {
-    return channelWriteCsv(check openWritableCsvFile(path, option=option), content);
+public isolated function fileWriteCsv(@untainted string path, string[][] content, FileWriteOption option = OVERWRITE) returns 
+Error? {
+    return channelWriteCsv(check openWritableCsvFile(path, option = option), content);
 }
 
 # Write CSV record stream to a file.
@@ -59,7 +59,7 @@ public isolated function fileWriteCsv(@untainted string path, string[][] content
 # + content - A CSV record stream to be written
 # + option - To indicate whether to overwrite or append the given content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content,
-                    FileWriteOption option = OVERWRITE) returns Error? {
-    return channelWriteCsvFromStream(check openWritableCsvFile(path, option=option), content);
+public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content, 
+                                                FileWriteOption option = OVERWRITE) returns Error? {
+    return channelWriteCsvFromStream(check openWritableCsvFile(path, option = option), content);
 }

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -21,12 +21,7 @@
 # + path - The path of the file
 # + return - The entire file content as a string or an `io:Error`
 public isolated function fileReadString(@untainted string path) returns @tainted string|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadString(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadString(check openReadableFile(path));
 }
 
 # Reads the entire file content as a list of lines.
@@ -36,12 +31,7 @@ public isolated function fileReadString(@untainted string path) returns @tainted
 # + path - The path of the file
 # + return - The file as list of lines or an `io:Error`
 public isolated function fileReadLines(@untainted string path) returns @tainted string[]|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadLines(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadLines(check openReadableFile(path));
 }
 
 # Reads file content as a stream of lines.
@@ -51,12 +41,7 @@ public isolated function fileReadLines(@untainted string path) returns @tainted 
 # + path - The path of the file
 # + return - The file content as a stream of strings or an `io:Error`
 public isolated function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error>|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadLinesAsStream(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadLinesAsStream(check openReadableFile(path));
 }
 
 # Reads file content as a JSON.
@@ -66,12 +51,7 @@ public isolated function fileReadLinesAsStream(@untainted string path) returns @
 # + path - The path of the JSON file
 # + return - The file content as a JSON object or an `io:Error`
 public isolated function fileReadJson(@untainted string path) returns @tainted json|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadJson(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadJson(check openReadableFile(path));
 }
 
 # Reads file content as an XML.
@@ -81,12 +61,7 @@ public isolated function fileReadJson(@untainted string path) returns @tainted j
 # + path - The path of the XML file
 # + return - The file content as an XML or an `io:Error`
 public isolated function fileReadXml(@untainted string path) returns @tainted xml|Error {
-    var byteChannel = openReadableFile(path);
-    if (byteChannel is ReadableByteChannel) {
-        return channelReadXml(byteChannel);
-    } else {
-        return byteChannel;
-    }
+    return channelReadXml(check openReadableFile(path));
 }
 
 # Write a string content to a file.
@@ -100,12 +75,7 @@ public isolated function fileReadXml(@untainted string path) returns @tainted xm
 # + return - The null `()` value when the writing was successful or an `io:Error`
 public isolated function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns
 Error? {
-    var byteChannel = openWritableFile(path, option);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteString(byteChannel, content);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteString(check openWritableFile(path, option), content);
 }
 
 # Write an array of lines to a file.
@@ -120,12 +90,7 @@ Error? {
 # + return - The null `()` value when the writing was successful or an `io:Error`
 public isolated function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns
 Error? {
-    var byteChannel = openWritableFile(path, option);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteLines(byteChannel, content);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteLines(check openWritableFile(path, option), content);
 }
 
 # Write stream of lines to a file.
@@ -141,12 +106,7 @@ Error? {
 # + return - The null `()` value when the writing was successful or an `io:Error`
 public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, FileWriteOption option =
                                          OVERWRITE) returns Error? {
-    var byteChannel = openWritableFile(path, option);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteLinesFromStream(byteChannel, lineStream);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteLinesFromStream(check openWritableFile(path, option), lineStream);
 }
 
 # Write a JSON to a file.
@@ -158,12 +118,7 @@ public isolated function fileWriteLinesFromStream(@untainted string path, stream
 # + content - JSON content to write
 # + return - The null `()` value when the writing was successful or an `io:Error`
 public isolated function fileWriteJson(@untainted string path, json content) returns @tainted Error? {
-    var byteChannel = openWritableFile(path);
-    if (byteChannel is WritableByteChannel) {
-        return channelWriteJson(byteChannel, content);
-    } else {
-        return byteChannel;
-    }
+    return channelWriteJson(check openWritableFile(path), content);
 }
 
 # Write XML content to a file.
@@ -178,7 +133,7 @@ public isolated function fileWriteJson(@untainted string path, json content) ret
 # + return - The null `()` value when the writing was successful or an `io:Error`
 public isolated function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption =
                              OVERWRITE) returns Error? {
-    WritableByteChannel|Error byteChannel;
+    WritableByteChannel byteChannel;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {
         if (fileWriteOption == APPEND) {
             return error ConfigurationError("The file append operation is not allowed for Document Entity");
@@ -186,21 +141,16 @@ public isolated function fileWriteXml(@untainted string path, xml content, *XmlW
         if (xml:length(content) > 1) {
             return error ConfigurationError("The XML Document can only contains single root");
         }
-        byteChannel = openWritableFile(path);
+        byteChannel = check openWritableFile(path);
     } else {
         if (fileWriteOption == APPEND) {
-            byteChannel = openWritableFile(path, APPEND);
+            byteChannel = check openWritableFile(path, APPEND);
         } else {
-            byteChannel = openWritableFile(path);
+            byteChannel = check openWritableFile(path);
         }
     }
-
-    if (byteChannel is WritableByteChannel) {
-        if (xmlOptions.doctype != ()) {
-            return channelWriteXml(byteChannel, content, xmlOptions.doctype);
-        }
-        return channelWriteXml(byteChannel, content);
-    } else {
-        return byteChannel;
+    if (xmlOptions.doctype != ()) {
+        return channelWriteXml(byteChannel, content, xmlOptions.doctype);
     }
+    return channelWriteXml(byteChannel, content);
 }

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -73,7 +73,7 @@ public isolated function fileReadXml(@untainted string path) returns @tainted xm
 # + content - String content to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns
+public isolated function fileWriteString(@untainted string path, string content, FileWriteOption option = OVERWRITE) returns 
 Error? {
     return channelWriteString(check openWritableFile(path, option), content);
 }
@@ -88,7 +88,7 @@ Error? {
 # + content - An array of string lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns
+public isolated function fileWriteLines(@untainted string path, string[] content, FileWriteOption option = OVERWRITE) returns 
 Error? {
     return channelWriteLines(check openWritableFile(path, option), content);
 }
@@ -104,8 +104,8 @@ Error? {
 # + lineStream -  A stream of lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, FileWriteOption option =
-                                         OVERWRITE) returns Error? {
+public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, 
+                                                  FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteLinesFromStream(check openWritableFile(path, option), lineStream);
 }
 
@@ -131,8 +131,8 @@ public isolated function fileWriteJson(@untainted string path, json content) ret
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
 # + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption =
-                             OVERWRITE) returns Error? {
+public isolated function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption = 
+                                      OVERWRITE) returns Error? {
     WritableByteChannel byteChannel;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {
         if (fileWriteOption == APPEND) {

--- a/io-ballerina/print.bal
+++ b/io-ballerina/print.bal
@@ -23,8 +23,7 @@ import ballerina/jballerina.java;
 public type Printable any|error|PrintableRawTemplate;
 
 # Represents raw templates.
-# For example:
-#   - `The respective int value is ${val}`
+# e.g: `The respective int value is ${val}`
 # + strings - string values of the template as an array
 # + insertions - parameterized values/expressions after evaluations as an array
 public type PrintableRawTemplate object {

--- a/io-ballerina/print.bal
+++ b/io-ballerina/print.bal
@@ -16,24 +16,101 @@
 
 import ballerina/jballerina.java;
 
-# Prints `any` or `error` value(s) to the STDOUT.
+# Define all the printable types.
+# 1. any typed value
+# 2. errors
+# 3. `io:PrintableRawTemplate` - an raw templated value
+public type Printable any|error|PrintableRawTemplate;
+
+# Represents raw templates.
+# For example:
+#   - `The respective int value is ${val}`
+# + strings - string values of the template as an array
+# + insertions - parameterized values/expressions after evaluations as an array
+public type PrintableRawTemplate object {
+    public string[] & readonly strings;
+    public Printable[] insertions;
+};
+
+# Prints `any`, `error`, or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT.
 #```ballerina
 #io:print("Start processing the CSV file from ", srcFileName);
 #```
-# 
+#
 # + values - The value(s) to be printed
-public isolated function print((any|error)... values) = @java:Method {
+public isolated function print(Printable... values) {
+    PrintableClassImpl[] printables = [];
+    foreach int i in 0 ..< (values.length()) {
+        printables[i] = new PrintableClassImpl(values[i]);
+    }
+    externPrint(...printables);
+}
+
+# Prints `any`, `error` or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT
+# followed by a new line.
+#```ballerina
+# io:println("Start processing the CSV file from ", srcFileName);
+#```
+#
+# + values - The value(s) to be printed
+public isolated function println(Printable... values) {
+    PrintableClassImpl[] printables = [];
+    foreach int i in 0 ..< (values.length()) {
+        printables[i] = new PrintableClassImpl(values[i]);
+    }
+    externPrintln(...printables);
+}
+
+class PrintableClassImpl {
+    Printable printable;
+
+    public isolated function init(Printable printable) {
+        self.printable = printable;
+    }
+    public isolated function toString() returns string {
+        Printable printable = self.printable;
+        if printable is PrintableRawTemplate {
+            return new PrintableRawTemplateImpl(printable).toString();
+        } else if printable is error {
+            return printable.toString();
+        } else {
+            return printable.toString();
+        }
+    }
+}
+
+class PrintableRawTemplateImpl {
+    *object:RawTemplate;
+    Printable[] insertions;
+
+    public isolated function init(PrintableRawTemplate printableRawTemplate) {
+        self.strings = printableRawTemplate.strings;
+        self.insertions = printableRawTemplate.insertions;
+    }
+    public isolated function toString() returns string {
+        Printable[] templeteInsertions = self.insertions;
+        string[] templeteStrings = self.strings;
+        string templatedString = templeteStrings[0];
+        foreach int i in 1 ..< (templeteStrings.length()) {
+            Printable templateInsert = templeteInsertions[i - 1];
+            if (templateInsert is PrintableRawTemplate) {
+                templatedString += new PrintableRawTemplateImpl(templateInsert).toString() + templeteStrings[i];
+            } else if (templateInsert is error) {
+                templatedString += templateInsert.toString() + templeteStrings[i];
+            } else {
+                templatedString += templateInsert.toString() + templeteStrings[i];
+            }
+        }
+        return templatedString;
+    }
+}
+
+isolated function externPrint(PrintableClassImpl... values) = @java:Method {
     name: "print",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
 } external;
 
-# Prints `any` or `error` value(s) to the STDOUT followed by a new line.
-#```ballerina
-#io:println("Start processing the CSV file from ", srcFileName);
-#```
-#  
-# + values - The value(s) to be printed
-public isolated function println((any|error)... values) = @java:Method {
+isolated function externPrintln(PrintableClassImpl... values) = @java:Method {
     name: "println",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.PrintUtils"
 } external;

--- a/io-ballerina/readable_byte_channel.bal
+++ b/io-ballerina/readable_byte_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # ReadableByteChannel represents an input resource (i.e file). which could be used to source bytes.

--- a/io-ballerina/readable_byte_channel.bal
+++ b/io-ballerina/readable_byte_channel.bal
@@ -47,12 +47,8 @@ public class ReadableByteChannel {
     #
     # + return - Either a read only `byte` array or else an `io:Error`
     public isolated function readAll() returns @tainted readonly & byte[]|Error {
-        var readResult = readAllBytes(self);
-        if (readResult is byte[]) {
-            return <readonly & byte[]>readResult.cloneReadOnly();
-        } else {
-            return readResult;
-        }
+        byte[] readResult = check readAllBytes(self);
+        return <readonly & byte[]>readResult.cloneReadOnly();
     }
 
     # Return a block stream that can be used to read all `byte` blocks as a stream.

--- a/io-ballerina/readable_character_channel.bal
+++ b/io-ballerina/readable_character_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a channel, which could be used to read characters through a given ReadableByteChannel.
@@ -126,8 +125,8 @@ public class ReadableCharacterChannel {
     }
 }
 
-isolated function initReadableCharacterChannel(ReadableCharacterChannel characterChannel, ReadableByteChannel byteChannel,
-                                      string charset) = @java:Method {
+isolated function initReadableCharacterChannel(ReadableCharacterChannel characterChannel, 
+                                               ReadableByteChannel byteChannel, string charset) = @java:Method {
     name: "initCharacterChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/readable_csv_channel.bal
+++ b/io-ballerina/readable_csv_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a ReadableCSVChannel which could be used to read records from CSV file.

--- a/io-ballerina/readable_data_channel.bal
+++ b/io-ballerina/readable_data_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a data channel for reading data.
@@ -122,7 +121,8 @@ public class ReadableDataChannel {
     }
 }
 
-isolated function initReadableDataChannel(ReadableDataChannel dataChannel, ReadableByteChannel byteChannel, string bOrder) = @java:Method {
+isolated function initReadableDataChannel(ReadableDataChannel dataChannel, ReadableByteChannel byteChannel, 
+                                          string bOrder) = @java:Method {
     name: "initReadableDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/readable_record_channel.bal
+++ b/io-ballerina/readable_record_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a channel which will allow to read.
@@ -28,7 +27,8 @@ public class ReadableTextRecordChannel {
     # + charChannel - CharacterChannel which will point to the input/output resource
     # + fs - Field separator (this could be a regex)
     # + rs - Record separator (this could be a regex)
-    public isolated function init(ReadableCharacterChannel charChannel, string fs = "", string rs = "", string fmt = "default") {
+    public isolated function init(ReadableCharacterChannel charChannel, string fs = "", string rs = "", 
+                                  string fmt = "default") {
         self.charChannel = charChannel;
         self.rs = rs;
         self.fs = fs;
@@ -67,8 +67,8 @@ public class ReadableTextRecordChannel {
     }
 }
 
-isolated function initReadableTextRecordChannel(ReadableTextRecordChannel textChannel, ReadableCharacterChannel charChannel,
-                                       string fs, string rs, string fmt) = @java:Method {
+isolated function initReadableTextRecordChannel(ReadableTextRecordChannel textChannel, 
+                                                ReadableCharacterChannel charChannel, string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;

--- a/io-ballerina/tests/console_io.bal
+++ b/io-ballerina/tests/console_io.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/test;
 import ballerina/jballerina.java;
 
@@ -23,18 +22,14 @@ function beforePrint() {
     initOutputStream();
 }
 
-@test:Config {
-    dependsOn: [testReadString]
-}
+@test:Config {}
 function testPrintString() {
     string s = "A Greeting from Ballerina...!!!";
     print(s);
     test:assertEquals(readOutputStream(), s);
 }
 
-@test:Config {
-    dependsOn: [testPrintString]
-}
+@test:Config {dependsOn: [testPrintString]}
 function testPrintlnString() {
     string s = "Hello World...!!!";
     string expectedOutput = s + "\n";
@@ -42,73 +37,56 @@ function testPrintlnString() {
     test:assertEquals(readOutputStream(), expectedOutput);
 }
 
-@test:Config{
-    dependsOn: [testPrintlnString]
-}
+@test:Config {dependsOn: [testPrintlnString]}
 function testPrintInt() {
     int v = 1000;
     print(v);
     test:assertEquals(readOutputStream(), "1000");
 }
 
-@test:Config{
-    dependsOn: [testPrintInt]
-}
+@test:Config {dependsOn: [testPrintInt]}
 function testPrintlnInt() {
     int v = 1;
     println(v);
     test:assertEquals(readOutputStream(), "1\n");
 }
 
-@test:Config{
-    dependsOn: [testPrintlnInt]
-}
+@test:Config {dependsOn: [testPrintlnInt]}
 function testPrintFloat() {
     float v = 1000;
     print(v);
     test:assertEquals(readOutputStream(), "1000.0");
 }
 
-@test:Config{
-    dependsOn: [testPrintFloat]
-}
+@test:Config {dependsOn: [testPrintFloat]}
 function testPrintlnFloat() {
     float v = 1;
     println(v);
     test:assertEquals(readOutputStream(), "1.0\n");
 }
 
-@test:Config{
-    dependsOn: [testPrintlnFloat]
-}
+@test:Config {dependsOn: [testPrintlnFloat]}
 function testPrintBoolean() {
     boolean b = false;
     print(b);
     test:assertEquals(readOutputStream(), "false");
 }
 
-@test:Config{
-    dependsOn: [testPrintBoolean]
-}
+@test:Config {dependsOn: [testPrintBoolean]}
 function testPrintlnBoolean() {
     boolean b = true;
     println(b);
     test:assertEquals(readOutputStream(), "true\n");
 }
 
-@test:Config{
-    dependsOn: [testPrintlnBoolean]
-}
+@test:Config {dependsOn: [testPrintlnBoolean]}
 function testPrintConnector() {
     Foo f = new Foo();
     print(f);
     test:assertEquals(readOutputStream(), "object io:Foo");
-
 }
 
-@test:Config{
-    dependsOn: [testPrintConnector]
-}
+@test:Config {dependsOn: [testPrintConnector]}
 function testPrintlnConnector() {
     Foo f = new Foo();
     println(f);
@@ -116,27 +94,21 @@ function testPrintlnConnector() {
 
 }
 
-@test:Config{
-    dependsOn: [testPrintlnConnector]
-}
+@test:Config {dependsOn: [testPrintlnConnector]}
 function testPrintFunctionPointer() {
     function (int, int) returns (int) addFunction = func1;
     print(addFunction);
     test:assertEquals(readOutputStream(), "function function (int,int) returns (int)");
 }
 
-@test:Config{
-    dependsOn: [testPrintFunctionPointer]
-}
+@test:Config {dependsOn: [testPrintFunctionPointer]}
 function testPrintlnFunctionPointer() {
     function (int, int) returns (int) addFunction = func1;
     println(addFunction);
     test:assertEquals(readOutputStream(), "function function (int,int) returns (int)\n");
 }
 
-@test:Config{
-    dependsOn: [testPrintlnFunctionPointer]
-}
+@test:Config {dependsOn: [testPrintlnFunctionPointer]}
 function testPrintVarargs() {
     string s1 = "Hello World...!!!";
     string s2 = "A Greeting from Ballerina...!!!";
@@ -146,9 +118,7 @@ function testPrintVarargs() {
     test:assertEquals(readOutputStream(), expectedOutput);
 }
 
-@test:Config{
-    dependsOn: [testPrintVarargs]
-}
+@test:Config {dependsOn: [testPrintVarargs]}
 function testPrintMixVarargs() {
     string s1 = "Hello World...!!!";
     int i1 = 123456789;
@@ -159,9 +129,7 @@ function testPrintMixVarargs() {
     test:assertEquals(readOutputStream(), expectedOutput);
 }
 
-@test:Config{
-    dependsOn: [testPrintMixVarargs]
-}
+@test:Config {dependsOn: [testPrintMixVarargs]}
 function testPrintlnVarargs() {
     string s1 = "Hello World...!!!";
     string s2 = "A Greeting from Ballerina...!!!";
@@ -171,12 +139,150 @@ function testPrintlnVarargs() {
     test:assertEquals(readOutputStream(), expectedOutput);
 }
 
-@test:Config{
-    dependsOn: [testPrintlnVarargs]
-}
+@test:Config {dependsOn: [testPrintlnVarargs]}
 function testPrintNewline() {
     string expectedOutput = "hello\n";
     print("hello\n");
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintNewline]}
+function testPrintRawTemplateWithTrue() {
+    boolean val = true;
+    string expectedOutput = "The respective boolean value is true";
+    print(`The respective boolean value is ${val}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithTrue]}
+function testPrintRawTemplateWithFalse() {
+    boolean val = false;
+    string expectedOutput = "The respective boolean value is false";
+    print(`The respective boolean ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithFalse]}
+function testPrintRawTemplateWithInt() {
+    int val = 1050;
+    string expectedOutput = "The respective int value is 1050";
+    print(`The respective int ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithInt]}
+function testPrintRawTemplateWithDecimal() {
+    decimal val = 1050.0967;
+    string expectedOutput = "The respective decimal value is 1050.0967";
+    print(`The respective decimal ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithDecimal]}
+function testPrintRawTemplateWithString() {
+    string val = "My String";
+    string expectedOutput = "The respective string value is My String";
+    print(`The respective string ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithString]}
+function testPrintRawTemplateWithStringAndQuotes() {
+    string val = "My String";
+    string expectedOutput = "The respective string value is 'My String'";
+    print(`The respective string ${`value is '${val}'`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateWithStringAndQuotes]}
+function testPrintRawTemplateNested() {
+    string s1 = "S1";
+    string s2 = "S2";
+    string s3 = "S3";
+    string s4 = "S4";
+    string s5 = "S5";
+    string expectedOutput = "string 01: S1; string 02: S2; string 03: S3; string 04: S4; string 05: S5";
+
+    print(`${`${`${`${`string 01: ${s1}`}; string 02: ${s2}`}; string 03: ${s3}`}; string 04: ${s4}`}; string 05: ${s5}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateNested]}
+function testPrintRawTemplateMultiple() {
+    string name1 = "James";
+    string name2 = "Lily";
+    string expectedOutput = "Hello James!!!. After long time. Why Lily didn't come?";
+    print(`Hello ${name1}!!!.`, " ", "After long time.", " ", `Why ${name2} didn't come?`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintRawTemplateMultiple]}
+function testPrintlnRawTemplateWithTrue() {
+    boolean val = true;
+    string expectedOutput = "The respective boolean value is true\n";
+    println(`The respective boolean value is ${val}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithTrue]}
+function testPrintlnRawTemplateWithFalse() {
+    boolean val = false;
+    string expectedOutput = "The respective boolean value is false\n";
+    println(`The respective boolean ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithFalse]}
+function testPrintlnRawTemplateWithInt() {
+    int val = 1050;
+    string expectedOutput = "The respective int value is 1050\n";
+    println(`The respective int ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithInt]}
+function testPrintlnRawTemplateWithDecimal() {
+    decimal val = 1050.0967;
+    string expectedOutput = "The respective decimal value is 1050.0967\n";
+    println(`The respective decimal ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithDecimal]}
+function testPrintlnRawTemplateWithString() {
+    string val = "My String";
+    string expectedOutput = "The respective string value is My String\n";
+    println(`The respective string ${`value is ${val}`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithString]}
+function testPrintlnRawTemplateWithStringAndQuotes() {
+    string val = "My String";
+    string expectedOutput = "The respective string value is 'My String'\n";
+    println(`The respective string ${`value is '${val}'`}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateWithStringAndQuotes]}
+function testPrintlnRawTemplateNested() {
+    string s1 = "S1";
+    string s2 = "S2";
+    string s3 = "S3";
+    string s4 = "S4";
+    string s5 = "S5";
+    string expectedOutput = "string 01: S1; string 02: S2; string 03: S3; string 04: S4; string 05: S5\n";
+    println(
+    `${`${`${`${`string 01: ${s1}`}; string 02: ${s2}`}; string 03: ${s3}`}; string 04: ${s4}`}; string 05: ${s5}`);
+    test:assertEquals(readOutputStream(), expectedOutput);
+}
+
+@test:Config {dependsOn: [testPrintlnRawTemplateNested]}
+function testPrintlnRawTemplateMultiple() {
+    string name1 = "James";
+    string name2 = "Lily";
+    string expectedOutput = "Hello James!!!. After long time. Why Lily didn't come?\n";
+    println(`Hello ${name1}!!!.`, " ", "After long time.", " ", `Why ${name2} didn't come?`);
     test:assertEquals(readOutputStream(), expectedOutput);
 }
 

--- a/io-ballerina/writable_character_channel.bal
+++ b/io-ballerina/writable_character_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a channel which could be used to write characters through a given WritableCharacterChannel.
@@ -136,13 +135,14 @@ isolated function populateDoctype(xml content, XmlDoctype doctype) returns strin
     return doctypeElement;
 }
 
-isolated function initWritableCharacterChannel(WritableCharacterChannel characterChannel, WritableByteChannel byteChannel,
-                                      string charset) = @java:Method {
+isolated function initWritableCharacterChannel(WritableCharacterChannel characterChannel, 
+                                               WritableByteChannel byteChannel, string charset) = @java:Method {
     name: "initCharacterChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-isolated function writeExtern(WritableCharacterChannel characterChannel, string content, int startOffset) returns int|Error = @java:Method {
+isolated function writeExtern(WritableCharacterChannel characterChannel, string content, int startOffset) returns int|
+Error = @java:Method {
     name: "write",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
@@ -157,8 +157,8 @@ isolated function writeXmlExtern(WritableCharacterChannel characterChannel, xml 
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 
-isolated function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties, string comment) returns
-Error? = @java:Method {
+isolated function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties, 
+                                        string comment) returns Error? = @java:Method {
     name: "writeProperties",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/io-ballerina/writable_data_channel.bal
+++ b/io-ballerina/writable_data_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents network byte order.
@@ -143,7 +142,8 @@ public class WritableDataChannel {
     }
 }
 
-isolated function initWritableDataChannel(WritableDataChannel dataChannel, WritableByteChannel byteChannel, string bOrder) = @java:Method {
+isolated function initWritableDataChannel(WritableDataChannel dataChannel, WritableByteChannel byteChannel, 
+                                          string bOrder) = @java:Method {
     name: "initWritableDataChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.DataChannelUtils"
 } external;

--- a/io-ballerina/writable_record_channel.bal
+++ b/io-ballerina/writable_record_channel.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/jballerina.java;
 
 # Represents a channel, which will allow to write records through a given WritableCharacterChannel.
@@ -30,8 +29,8 @@ public class WritableTextRecordChannel {
     #         "DEFAULT" (the format specified by the CSVChannel), 
     #         "CSV" (Field separator would be "," and record separator would be a new line) or else
     #         "TDF" (Field separator will be a tab and record separator will be a new line). 
-    public isolated function init(WritableCharacterChannel characterChannel, string fs = "", string rs = "", string fmt =
-                         "default") {
+    public isolated function init(WritableCharacterChannel characterChannel, string fs = "", string rs = "", 
+                                  string fmt = "default") {
         self.characterChannel = characterChannel;
         self.fs = fs;
         self.rs = rs;
@@ -61,8 +60,8 @@ public class WritableTextRecordChannel {
     }
 }
 
-isolated function initWritableTextRecordChannel(WritableTextRecordChannel textChannel, WritableCharacterChannel charChannel,
-                                       string fs, string rs, string fmt) = @java:Method {
+isolated function initWritableTextRecordChannel(WritableTextRecordChannel textChannel, 
+                                                WritableCharacterChannel charChannel, string fs, string rs, string fmt) = @java:Method {
     name: "initRecordChannel",
     'class: "org.ballerinalang.stdlib.io.nativeimpl.RecordChannelUtils"
 } external;


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1050

## Approach
Add raw template support by implementing `toString()` APIs.

## Automation tests
 - Unit tests 
   > Yes


## Samples
```ballerina
string val = "John";
io:println(`Hello ${val}!!!`);
io:print(`Hello ${val}!!!`);
```

## Test environment
- macOS
- Java11
- SLA3