### PR TITLE
Adhere to the stream completion with nil changes

### DIFF
--- a/io-ballerina/channel_byte_io.bal
+++ b/io-ballerina/channel_byte_io.bal
@@ -28,7 +28,7 @@ isolated function channelReadBytes(ReadableChannel readableChannel) returns @tai
 }
 
 isolated function channelReadBlocksAsStream(ReadableChannel readableChannel, int blockSize = 4096) returns @tainted stream<
-Block, Error>|Error {
+Block, Error?>|Error {
     if (readableChannel is ReadableByteChannel) {
         return readableChannel.blockStream(blockSize);
     } else {
@@ -52,7 +52,7 @@ isolated function channelWriteBytes(WritableChannel writableChannel, byte[] cont
     }
 }
 
-isolated function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[], Error> byteStream) returns 
+isolated function channelWriteBlocksFromStream(WritableChannel writableChannel, stream<byte[], Error?> byteStream) returns
 Error? {
     if (writableChannel is WritableByteChannel) {
         record {| byte[] value; |}|Error? block = byteStream.next();

--- a/io-ballerina/channel_csv_io.bal
+++ b/io-ballerina/channel_csv_io.bal
@@ -35,7 +35,7 @@ Error {
     return results;
 }
 
-isolated function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[], Error>|
+isolated function channelReadCsvAsStream(ReadableChannel readableChannel) returns @tainted stream<string[], Error?>|
 Error {
     return (check getReadableCSVChannel(readableChannel, 0)).csvStream();
 }
@@ -52,7 +52,7 @@ isolated function channelWriteCsv(WritableChannel writableChannel, string[][] co
     check csvChannel.close();
 }
 
-isolated function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[], Error> csvStream) returns 
+isolated function channelWriteCsvFromStream(WritableChannel writableChannel, stream<string[], Error?> csvStream) returns
 Error? {
     WritableCSVChannel csvChannel = check getWritableCSVChannel(writableChannel);
     record {| string[] value; |}|Error? csvRecord = csvStream.next();

--- a/io-ballerina/channel_string_io.bal
+++ b/io-ballerina/channel_string_io.bal
@@ -29,7 +29,7 @@ isolated function channelReadLines(ReadableChannel readableChannel) returns @tai
     return result;
 }
 
-isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error>|
+isolated function channelReadLinesAsStream(ReadableChannel readableChannel) returns @tainted stream<string, Error?>|
 Error {
     return (check getReadableCharacterChannel(readableChannel)).lineStream();
 }
@@ -76,7 +76,7 @@ isolated function channelWriteLines(WritableChannel writableChannel, string[] co
     }
 }
 
-isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error> lineStream) returns 
+isolated function channelWriteLinesFromStream(WritableChannel writableChannel, stream<string, Error?> lineStream) returns
 Error? {
     WritableCharacterChannel characterChannel = check getWritableCharacterChannel(writableChannel);
     record {| string value; |}|Error? line = lineStream.next();

--- a/io-ballerina/file_byte_io.bal
+++ b/io-ballerina/file_byte_io.bal
@@ -26,12 +26,12 @@ public isolated function fileReadBytes(@untainted string path) returns @tainted 
 
 # Read the entire file content as a stream of blocks.
 # ```ballerina
-# stream<io:Block, io:Error>|io:Error content = io:fileReadBlocksAsStream("./resources/myfile.txt", 1000);
+# stream<io:Block, io:Error?>|io:Error content = io:fileReadBlocksAsStream("./resources/myfile.txt", 1000);
 # ```
 # + path - The path of the file
 # + blockSize - An optional size of the byte block. Default size is 4KB
 # + return - Either a byte block stream or `io:Error`
-public isolated function fileReadBlocksAsStream(string path, int blockSize = 4096) returns @tainted stream<Block, Error>|
+public isolated function fileReadBlocksAsStream(string path, int blockSize = 4096) returns @tainted stream<Block, Error?>|
 Error {
     return channelReadBlocksAsStream(check openReadableFile(path), blockSize);
 }
@@ -53,14 +53,14 @@ Error? {
 # Write a byte stream to a file.
 # ```ballerina
 # byte[] content = [[60, 78, 39, 28]];
-# stream<byte[], io:Error> byteStream = content.toStream();
+# stream<byte[], io:Error?> byteStream = content.toStream();
 # io:Error? result = io:fileWriteBlocksFromStream("./resources/myfile.txt", byteStream);
 # ```
 # + path - The path of the file
 # + byteStream - Byte stream to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - `io:Error` or else `()`
-public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error> byteStream, 
+public isolated function fileWriteBlocksFromStream(@untainted string path, stream<byte[], Error?> byteStream,
                                                    FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteBlocksFromStream(check openWritableFile(path, option), byteStream);
 }

--- a/io-ballerina/file_csv_io.bal
+++ b/io-ballerina/file_csv_io.bal
@@ -27,11 +27,11 @@ public isolated function fileReadCsv(@untainted string path, int skipHeaders = 0
 
 # Read file content as a CSV.
 # ```ballerina
-# stream<string[], io:Error>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
+# stream<string[], io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
-public isolated function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error>|Error {
+public isolated function fileReadCsvAsStream(@untainted string path) returns @tainted stream<string[], Error?>|Error {
     return (check openReadableCsvFile(path)).csvStream();
 }
 
@@ -52,14 +52,14 @@ Error? {
 # Write CSV record stream to a file.
 # ```ballerina
 # string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
-# stream<string[], io:Error> recordStream = content.toStream();
+# stream<string[], io:Error?> recordStream = content.toStream();
 # io:Error? result = io:fileWriteCsvFromStream("./resources/myfile.csv", recordStream);
 # ```
 # + path - The CSV file path
 # + content - A CSV record stream to be written
 # + option - To indicate whether to overwrite or append the given content
 # + return - Either an `io:Error` or the null `()` value when the writing was successful
-public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error> content, 
+public isolated function fileWriteCsvFromStream(@untainted string path, stream<string[], Error?> content,
                                                 FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteCsvFromStream(check openWritableCsvFile(path, option = option), content);
 }

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -36,11 +36,11 @@ public isolated function fileReadLines(@untainted string path) returns @tainted 
 
 # Reads file content as a stream of lines.
 # ```ballerina
-# stream<string, io:Error>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
+# stream<string, io:Error?>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
 # ```
 # + path - The path of the file
 # + return - The file content as a stream of strings or an `io:Error`
-public isolated function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error>|Error {
+public isolated function fileReadLinesAsStream(@untainted string path) returns @tainted stream<string, Error?>|Error {
     return channelReadLinesAsStream(check openReadableFile(path));
 }
 
@@ -97,14 +97,14 @@ Error? {
 # During the writing operation, a newline character `\n` will be added after each line.
 # ```ballerina
 # string content = ["Hello Universe..!!", "How are you?"];
-# stream<string, io:Error> lineStream = content.toStream();
+# stream<string, io:Error?> lineStream = content.toStream();
 # io:Error? result = io:fileWriteLinesFromStream("./resources/myfile.txt", lineStream);
 # ```
 # + path - The path of the file
 # + lineStream -  A stream of lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error> lineStream, 
+public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error?> lineStream,
                                                   FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteLinesFromStream(check openWritableFile(path, option), lineStream);
 }

--- a/io-ballerina/readable_byte_channel.bal
+++ b/io-ballerina/readable_byte_channel.bal
@@ -56,9 +56,9 @@ public class ReadableByteChannel {
     # ```
     # + blockSize - A positive integer. Size of the block.
     # + return - Either a block stream or else an `io:Error`
-    public isolated function blockStream(int blockSize) returns @tainted stream<Block, Error>|Error {
+    public isolated function blockStream(int blockSize) returns @tainted stream<Block, Error?>|Error {
         BlockStream blockStream = new (self, blockSize);
-        return new stream<Block, Error>(blockStream);
+        return new stream<Block, Error?>(blockStream);
     }
 
     # Encodes a given `ReadableByteChannel` using the Base64 encoding scheme.

--- a/io-ballerina/readable_character_channel.bal
+++ b/io-ballerina/readable_character_channel.bal
@@ -98,9 +98,9 @@ public class ReadableCharacterChannel {
     # ```
     #
     # + return - Either a stream of strings(lines) or an io:Error.
-    public isolated function lineStream() returns stream<string, Error>|Error {
+    public isolated function lineStream() returns stream<string, Error?>|Error {
         LineStream lineStream = new (self);
-        return new stream<string, Error>(lineStream);
+        return new stream<string, Error?>(lineStream);
     }
 
     # Reads all properties from a .properties file.

--- a/io-ballerina/readable_csv_channel.bal
+++ b/io-ballerina/readable_csv_channel.bal
@@ -87,11 +87,11 @@ public class ReadableCSVChannel {
     # ```
     #
     # + return - Either a stream of records(string[]) or else an `io:Error`
-    public isolated function csvStream() returns stream<string[], Error>|Error {
+    public isolated function csvStream() returns stream<string[], Error?>|Error {
         var recordChannel = self.dc;
         if (recordChannel is ReadableTextRecordChannel) {
             CSVStream csvStream = new (recordChannel);
-            return new stream<string[], Error>(csvStream);
+            return new stream<string[], Error?>(csvStream);
         } else {
             GenericError e = error GenericError("channel not initialized");
             panic e;

--- a/io-ballerina/tests/bytes_io.bal
+++ b/io-ballerina/tests/bytes_io.bal
@@ -109,8 +109,8 @@ isolated function testFileReadBytes() {
 }
 
 @test:Config {}
-isolated function testFileWriteBytesFromStream() returns Error? {
-    string filePath = TEMP_DIR + "bytesFile3.txt";
+isolated function testFileWriteBytesFromStreamUsingIntermediateFile() returns Error? {
+    string filePath = TEMP_DIR + "bytesFile3_A.txt";
     string resourceFilePath = TEMP_DIR + "bytesResourceFile.txt";
     string content = "Sheldon Cooper";
     check fileWriteString(resourceFilePath, content);
@@ -121,9 +121,48 @@ isolated function testFileWriteBytesFromStream() returns Error? {
     }
 }
 
+@test:Config {dependsOn: [testFileWriteBytesFromStreamUsingIntermediateFile]}
+function testFileReadBytesAsStreamUsingIntermediateFile() {
+    string filePath = TEMP_DIR + "bytesFile3_A.txt";
+    var result = fileReadBlocksAsStream(filePath, 2);
+    string expectedString = "Sheldon Cooper";
+    byte[] byteArr = [];
+    if (result is stream<Block, Error?>) {
+        error? e = result.forEach(function(Block val) {
+            foreach byte b in val {
+                byteArr.push(b);
+            }
+        });
+        string|error returnedString = langstring:fromBytes(byteArr);
+        if (returnedString is string) {
+            test:assertEquals(returnedString, expectedString);
+        } else {
+            test:assertFail(msg = returnedString.message());
+        }
+    } else {
+        test:assertFail(msg = result.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteBytesFromStream() {
+    string filePath = TEMP_DIR + "bytesFile3_B.txt";
+    string[] stringContent = ["Sheldon", " ", "Cooper"];
+    byte[][] byteContent = [];
+    int i = 0;
+    foreach string s in stringContent {
+        byteContent[i] = s.toBytes();
+        i += 1;
+    }
+    var result = fileWriteBlocksFromStream(filePath, byteContent.toStream());
+    if (result is Error) {
+        test:assertFail(msg = result.message());
+    }
+}
+
 @test:Config {dependsOn: [testFileWriteBytesFromStream]}
 function testFileReadBytesAsStream() {
-    string filePath = TEMP_DIR + "bytesFile3.txt";
+    string filePath = TEMP_DIR + "bytesFile3_B.txt";
     var result = fileReadBlocksAsStream(filePath, 2);
     string expectedString = "Sheldon Cooper";
     byte[] byteArr = [];
@@ -306,7 +345,7 @@ isolated function testFileWriteBytesWithAppend() {
 }
 
 @test:Config {}
-function testFileWriteBytesFromStreamWithOverride() returns Error? {
+function testFileWriteBytesFromStreamWithOverrideUsingIntermediateFile() returns Error? {
     string filePath = TEMP_DIR + "bytesFile8.txt";
     string resourceFilePath1 = TEMP_DIR + "bytesResourceFile1.txt";
     string resourceFilePath2 = TEMP_DIR + "bytesResourceFile2.txt";
@@ -365,7 +404,7 @@ function testFileWriteBytesFromStreamWithOverride() returns Error? {
 }
 
 @test:Config {}
-function testFileWriteBytesFromStreamWithAppend() returns Error? {
+function testFileWriteBytesFromStreamWithAppendUsingIntermediateFile() returns Error? {
     string filePath = TEMP_DIR + "bytesFile8.txt";
     string resourceFilePath1 = TEMP_DIR + "bytesResourceFile3.txt";
     string resourceFilePath2 = TEMP_DIR + "bytesResourceFile4.txt";
@@ -415,6 +454,138 @@ function testFileWriteBytesFromStreamWithAppend() returns Error? {
         string|error returnedString = langstring:fromBytes(byteArr2);
         if (returnedString is string) {
             test:assertEquals(returnedString, (content1 + content2));
+        } else {
+            test:assertFail(msg = returnedString.message());
+        }
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteBytesFromStreamWithOverride() {
+    string filePath = TEMP_DIR + "bytesFile9.txt";
+    string[] content1 = ["Ballerina ", "is ", "an "];
+    string[] content2 = ["open ", "source ", "programming ", "language"];
+    string expectedContent1 = "Ballerina is an ";
+    string expectedContent2 = "open source programming language";
+    byte[][] byteContent1 = [];
+    byte[][] byteContent2 = [];
+    int i = 0;
+    foreach string s in content1 {
+        byteContent1[i] = s.toBytes();
+        i += 1;
+    }
+    i = 0;
+    foreach string s in content2 {
+        byteContent2[i] = s.toBytes();
+        i += 1;
+    }
+    // Check content 01
+    var result1 = fileWriteBlocksFromStream(filePath, byteContent1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadBlocksAsStream(filePath, 2);
+    byte[] byteArr1 = [];
+    if (result2 is stream<Block, Error?>) {
+        error? e = result2.forEach(function(Block val) {
+            foreach byte b in val {
+                byteArr1.push(b);
+            }
+        });
+        string|error returnedString = langstring:fromBytes(byteArr1);
+        if (returnedString is string) {
+            test:assertEquals(returnedString, expectedContent1);
+        } else {
+            test:assertFail(msg = returnedString.message());
+        }
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteBlocksFromStream(filePath, byteContent2.toStream());
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadBlocksAsStream(filePath, 2);
+    byte[] byteArr2 = [];
+    if (result4 is stream<Block, Error?>) {
+        error? e = result4.forEach(function(Block val) {
+            foreach byte b in val {
+                byteArr2.push(b);
+            }
+        });
+        string|error returnedString = langstring:fromBytes(byteArr2);
+        if (returnedString is string) {
+            test:assertEquals(returnedString, expectedContent2);
+        } else {
+            test:assertFail(msg = returnedString.message());
+        }
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteBytesFromStreamWithAppend() {
+    string filePath = TEMP_DIR + "bytesFile9.txt";
+    string[] content1 = ["Ballerina ", "is ", "an "];
+    string[] content2 = ["open ", "source ", "programming ", "language"];
+    string expectedContent1 = "Ballerina is an ";
+    string expectedContent2 = "Ballerina is an open source programming language";
+    byte[][] byteContent1 = [];
+    byte[][] byteContent2 = [];
+    int i = 0;
+    foreach string s in content1 {
+        byteContent1[i] = s.toBytes();
+        i += 1;
+    }
+    i = 0;
+    foreach string s in content2 {
+        byteContent2[i] = s.toBytes();
+        i += 1;
+    }
+    // Check content 01
+    var result1 = fileWriteBlocksFromStream(filePath, byteContent1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadBlocksAsStream(filePath, 2);
+    byte[] byteArr1 = [];
+    if (result2 is stream<Block, Error?>) {
+        error? e = result2.forEach(function(Block val) {
+            foreach byte b in val {
+                byteArr1.push(b);
+            }
+        });
+        string|error returnedString = langstring:fromBytes(byteArr1);
+        if (returnedString is string) {
+            test:assertEquals(returnedString, expectedContent1);
+        } else {
+            test:assertFail(msg = returnedString.message());
+        }
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 01 + 02
+    var result3 = fileWriteBlocksFromStream(filePath, byteContent2.toStream(), APPEND);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadBlocksAsStream(filePath, 2);
+    byte[] byteArr2 = [];
+    if (result4 is stream<Block, Error?>) {
+        error? e = result4.forEach(function(Block val) {
+            foreach byte b in val {
+                byteArr2.push(b);
+            }
+        });
+        string|error returnedString = langstring:fromBytes(byteArr2);
+        if (returnedString is string) {
+            test:assertEquals(returnedString, expectedContent2);
         } else {
             test:assertFail(msg = returnedString.message());
         }

--- a/io-ballerina/tests/bytes_io.bal
+++ b/io-ballerina/tests/bytes_io.bal
@@ -114,7 +114,7 @@ isolated function testFileWriteBytesFromStream() returns Error? {
     string resourceFilePath = TEMP_DIR + "bytesResourceFile.txt";
     string content = "Sheldon Cooper";
     check fileWriteString(resourceFilePath, content);
-    stream<Block, Error> bytesStream = check fileReadBlocksAsStream(resourceFilePath, 2);
+    stream<Block, Error?> bytesStream = check fileReadBlocksAsStream(resourceFilePath, 2);
     var result = fileWriteBlocksFromStream(filePath, bytesStream);
     if (result is Error) {
         test:assertFail(msg = result.message());
@@ -127,7 +127,7 @@ function testFileReadBytesAsStream() {
     var result = fileReadBlocksAsStream(filePath, 2);
     string expectedString = "Sheldon Cooper";
     byte[] byteArr = [];
-    if (result is stream<Block, Error>) {
+    if (result is stream<Block, Error?>) {
         error? e = result.forEach(function(Block val) {
             foreach byte b in val {
                 byteArr.push(b);
@@ -184,7 +184,7 @@ isolated function testFileChannelWriteBytesFromStream() returns Error? {
     string resourceFilePath = TEMP_DIR + "bytesResourceFile.txt";
     string content = "Sheldon Cooper";
     check fileWriteString(resourceFilePath, content);
-    stream<Block, Error> bytesStream = check fileReadBlocksAsStream(resourceFilePath, 2);
+    stream<Block, Error?> bytesStream = check fileReadBlocksAsStream(resourceFilePath, 2);
     var fileOpenResult = openWritableFile(filePath);
     if (fileOpenResult is WritableByteChannel) {
         var result = channelWriteBlocksFromStream(fileOpenResult, bytesStream);
@@ -205,7 +205,7 @@ function testFileChannelReadBytesAsStream() {
     var fileOpenResult = openReadableFile(filePath);
     if (fileOpenResult is ReadableByteChannel) {
         var result = channelReadBlocksAsStream(fileOpenResult, 2);
-        if (result is stream<Block, Error>) {
+        if (result is stream<Block, Error?>) {
             error? e = result.forEach(function(Block val) {
                                    foreach byte b in val {
                                        byteArr.push(b);
@@ -314,8 +314,8 @@ function testFileWriteBytesFromStreamWithOverride() returns Error? {
     string content2 = "open source programming language";
     check fileWriteString(resourceFilePath1, content1);
     check fileWriteString(resourceFilePath2, content2);
-    stream<Block, Error> bytesStream1 = check fileReadBlocksAsStream(resourceFilePath1, 2);
-    stream<Block, Error> bytesStream2 = check fileReadBlocksAsStream(resourceFilePath2, 2);
+    stream<Block, Error?> bytesStream1 = check fileReadBlocksAsStream(resourceFilePath1, 2);
+    stream<Block, Error?> bytesStream2 = check fileReadBlocksAsStream(resourceFilePath2, 2);
 
     // Check content 01
     var result1 = fileWriteBlocksFromStream(filePath, bytesStream1);
@@ -324,7 +324,7 @@ function testFileWriteBytesFromStreamWithOverride() returns Error? {
     }
     var result2 = fileReadBlocksAsStream(filePath, 2);
     byte[] byteArr1 = [];
-    if (result2 is stream<Block, Error>) {
+    if (result2 is stream<Block, Error?>) {
         error? e = result2.forEach(function(Block val) {
             foreach byte b in val {
                 byteArr1.push(b);
@@ -347,7 +347,7 @@ function testFileWriteBytesFromStreamWithOverride() returns Error? {
     }
     var result4 = fileReadBlocksAsStream(filePath, 2);
     byte[] byteArr2 = [];
-    if (result4 is stream<Block, Error>) {
+    if (result4 is stream<Block, Error?>) {
         error? e = result4.forEach(function(Block val) {
             foreach byte b in val {
                 byteArr2.push(b);
@@ -373,8 +373,8 @@ function testFileWriteBytesFromStreamWithAppend() returns Error? {
     string content2 = "open source programming language";
     check fileWriteString(resourceFilePath1, content1);
     check fileWriteString(resourceFilePath2, content2);
-    stream<Block, Error> bytesStream1 = check fileReadBlocksAsStream(resourceFilePath1, 2);
-    stream<Block, Error> bytesStream2 = check fileReadBlocksAsStream(resourceFilePath2, 2);
+    stream<Block, Error?> bytesStream1 = check fileReadBlocksAsStream(resourceFilePath1, 2);
+    stream<Block, Error?> bytesStream2 = check fileReadBlocksAsStream(resourceFilePath2, 2);
 
     // Check content 01
     var result1 = fileWriteBlocksFromStream(filePath, bytesStream1);
@@ -383,7 +383,7 @@ function testFileWriteBytesFromStreamWithAppend() returns Error? {
     }
     var result2 = fileReadBlocksAsStream(filePath, 2);
     byte[] byteArr1 = [];
-    if (result2 is stream<Block, Error>) {
+    if (result2 is stream<Block, Error?>) {
         error? e = result2.forEach(function(Block val) {
             foreach byte b in val {
                 byteArr1.push(b);
@@ -406,7 +406,7 @@ function testFileWriteBytesFromStreamWithAppend() returns Error? {
     }
     var result4 = fileReadBlocksAsStream(filePath, 2);
     byte[] byteArr2 = [];
-    if (result4 is stream<Block, Error>) {
+    if (result4 is stream<Block, Error?>) {
         error? e = result4.forEach(function(Block val) {
             foreach byte b in val {
                 byteArr2.push(b);

--- a/io-ballerina/tests/csv_io.bal
+++ b/io-ballerina/tests/csv_io.bal
@@ -655,8 +655,8 @@ isolated function testFileCsvReadWithSkipHeaders() {
 }
 
 @test:Config {}
-isolated function testFileWriteCsvFromStream() returns Error? {
-    string filePath = TEMP_DIR + "workers4.csv";
+isolated function testFileWriteCsvFromStreamUsingResourceFile() returns Error? {
+    string filePath = TEMP_DIR + "workers4_A.csv";
     string resourceFilePath = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
     stream<string[], Error?> csvStream = check fileReadCsvAsStream(resourceFilePath);
     var result = fileWriteCsvFromStream(filePath, csvStream);
@@ -665,9 +665,9 @@ isolated function testFileWriteCsvFromStream() returns Error? {
     }
 }
 
-@test:Config {dependsOn: [testFileWriteCsvFromStream]}
-function testFileReadCsvAsStream() {
-    string filePath = TEMP_DIR + "workers4.csv";
+@test:Config {dependsOn: [testFileWriteCsvFromStreamUsingResourceFile]}
+function testFileReadCsvAsStreamUsingResourceFile() {
+    string filePath = TEMP_DIR + "workers4_A.csv";
     string[][] expectedContent = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], [
     "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", 
     "30 years", "Colombo"]];
@@ -678,6 +678,44 @@ function testFileReadCsvAsStream() {
                                int j = 0;
                                foreach string s in val {
                                    test:assertEquals('string:trim(s), expectedContent[i][j]);
+                                   j += 1;
+                               }
+                               i += 1;
+                           });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 3);
+    } else {
+        test:assertFail(msg = result.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteCsvFromStream() {
+    string filePath = TEMP_DIR + "workers4_B.csv";
+    string[][] content = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
+    "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
+    "Colombo"]];
+    var result = fileWriteCsvFromStream(filePath, content.toStream());
+    if (result is Error) {
+        test:assertFail(msg = result.message());
+    }
+}
+
+@test:Config {dependsOn: [testFileWriteCsvFromStream]}
+function testFileReadCsvAsStream() {
+    string filePath = TEMP_DIR + "workers4_B.csv";
+    string[][] expectedContent = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], [
+    "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank",
+    "30 years", "Colombo"]];
+    var result = fileReadCsvAsStream(filePath);
+    if (result is stream<string[], Error?>) {
+        int i = 0;
+        error? e = result.forEach(function(string[] val) {
+                               int j = 0;
+                               foreach string s in val {
+                                   test:assertEquals(s, expectedContent[i][j]);
                                    j += 1;
                                }
                                i += 1;
@@ -797,7 +835,7 @@ isolated function testFileCsvWriteWithAppend() {
 }
 
 @test:Config {}
-function testFileCsvWriteFromStreamWithOverwrite() returns Error? {
+function testFileCsvWriteFromStreamWithOverwriteUsingResourceFile() returns Error? {
     string filePath = TEMP_DIR + "workers5.csv";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "csvResourceFile2.csv";
@@ -859,7 +897,7 @@ function testFileCsvWriteFromStreamWithOverwrite() returns Error? {
 }
 
 @test:Config {}
-function testFileCsvWriteFromStreamWithAppend() returns Error? {
+function testFileCsvWriteFromStreamWithAppendUsingResourceFile() returns Error? {
     string filePath = TEMP_DIR + "workers6.csv";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "csvResourceFile2.csv";
@@ -910,6 +948,127 @@ function testFileCsvWriteFromStreamWithAppend() returns Error? {
                                int j = 0;
                                foreach string s in val {
                                    test:assertEquals('string:trim(s), expectedCsv[i][j]);
+                                   j += 1;
+                               }
+                               i += 1;
+                           });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 6);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileCsvWriteFromStreamWithOverwrite() {
+    string filePath = TEMP_DIR + "workers7.csv";
+    string[][] content1 = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
+    "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
+    "Colombo"]];
+    string[][] content2 = [["Distributed Computing", "A001", "Prof. Jack"], ["Quantum Computing", "A002", "Dr. Sam"],
+    ["Artificail Intelligence", "A003", "Prof. Angelina"]];
+
+    // Check content 01
+    var result1 = fileWriteCsvFromStream(filePath, content1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadCsvAsStream(filePath);
+    if (result2 is stream<string[], Error?>) {
+        int i = 0;
+        error? e = result2.forEach(function(string[] val) {
+                               int j = 0;
+                               foreach string s in val {
+                                   test:assertEquals(s, content1[i][j]);
+                                   j += 1;
+                               }
+                               i += 1;
+                           });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 3);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteCsvFromStream(filePath, content2.toStream());
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadCsvAsStream(filePath);
+    if (result4 is stream<string[], Error?>) {
+        int i = 0;
+        error? e = result4.forEach(function(string[] val) {
+                               int j = 0;
+                               foreach string s in val {
+                                   test:assertEquals(s, content2[i][j]);
+                                   j += 1;
+                               }
+                               i += 1;
+                           });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 3);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileCsvWriteFromStreamWithAppend() {
+    string filePath = TEMP_DIR + "workers8.csv";
+    string[][] content1 = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
+    "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
+    "Colombo"]];
+    string[][] content2 = [["Distributed Computing", "A001", "Prof. Jack"], ["Quantum Computing", "A002", "Dr. Sam"],
+    ["Artificail Intelligence", "A003", "Prof. Angelina"]];
+    string[][] expectedCsv = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"],
+    ["John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"],
+    ["Mary Thompson", "Banker", "Sampath Bank", "30 years", "Colombo"],
+    ["Distributed Computing", "A001", "Prof. Jack"], ["Quantum Computing", "A002", "Dr. Sam"],
+    ["Artificail Intelligence", "A003", "Prof. Angelina"]];
+
+    // Check content 01
+    var result1 = fileWriteCsvFromStream(filePath, content1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadCsvAsStream(filePath);
+    if (result2 is stream<string[], Error?>) {
+        int i = 0;
+        error? e = result2.forEach(function(string[] val) {
+                               int j = 0;
+                               foreach string s in val {
+                                   test:assertEquals(s, content1[i][j]);
+                                   j += 1;
+                               }
+                               i += 1;
+                           });
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 3);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteCsvFromStream(filePath, content2.toStream(), APPEND);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadCsvAsStream(filePath);
+    if (result4 is stream<string[], Error?>) {
+        int i = 0;
+        error? e = result4.forEach(function(string[] val) {
+                               int j = 0;
+                               foreach string s in val {
+                                   test:assertEquals(s, expectedCsv[i][j]);
                                    j += 1;
                                }
                                i += 1;

--- a/io-ballerina/tests/csv_io.bal
+++ b/io-ballerina/tests/csv_io.bal
@@ -658,7 +658,7 @@ isolated function testFileCsvReadWithSkipHeaders() {
 isolated function testFileWriteCsvFromStream() returns Error? {
     string filePath = TEMP_DIR + "workers4.csv";
     string resourceFilePath = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
-    stream<string[], Error> csvStream = check fileReadCsvAsStream(resourceFilePath);
+    stream<string[], Error?> csvStream = check fileReadCsvAsStream(resourceFilePath);
     var result = fileWriteCsvFromStream(filePath, csvStream);
     if (result is Error) {
         test:assertFail(msg = result.message());
@@ -672,7 +672,7 @@ function testFileReadCsvAsStream() {
     "John Thomson", "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", 
     "30 years", "Colombo"]];
     var result = fileReadCsvAsStream(filePath);
-    if (result is stream<string[], Error>) {
+    if (result is stream<string[], Error?>) {
         int i = 0;
         error? e = result.forEach(function(string[] val) {
                                int j = 0;
@@ -801,8 +801,8 @@ function testFileCsvWriteFromStreamWithOverwrite() returns Error? {
     string filePath = TEMP_DIR + "workers5.csv";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "csvResourceFile2.csv";
-    stream<string[], Error> csvStream1 = check fileReadCsvAsStream(resourceFilePath1);
-    stream<string[], Error> csvStream2 = check fileReadCsvAsStream(resourceFilePath2);
+    stream<string[], Error?> csvStream1 = check fileReadCsvAsStream(resourceFilePath1);
+    stream<string[], Error?> csvStream2 = check fileReadCsvAsStream(resourceFilePath2);
     string[][] content1 = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
     "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
     "Colombo"]];
@@ -815,7 +815,7 @@ function testFileCsvWriteFromStreamWithOverwrite() returns Error? {
         test:assertFail(msg = result1.message());
     }
     var result2 = fileReadCsvAsStream(filePath);
-    if (result2 is stream<string[], Error>) {
+    if (result2 is stream<string[], Error?>) {
         int i = 0;
         error? e = result2.forEach(function(string[] val) {
                                int j = 0;
@@ -839,7 +839,7 @@ function testFileCsvWriteFromStreamWithOverwrite() returns Error? {
         test:assertFail(msg = result3.message());
     }
     var result4 = fileReadCsvAsStream(filePath);
-    if (result4 is stream<string[], Error>) {
+    if (result4 is stream<string[], Error?>) {
         int i = 0;
         error? e = result4.forEach(function(string[] val) {
                                int j = 0;
@@ -863,8 +863,8 @@ function testFileCsvWriteFromStreamWithAppend() returns Error? {
     string filePath = TEMP_DIR + "workers6.csv";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "csvResourceFile1.csv";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "csvResourceFile2.csv";
-    stream<string[], Error> csvStream1 = check fileReadCsvAsStream(resourceFilePath1);
-    stream<string[], Error> csvStream2 = check fileReadCsvAsStream(resourceFilePath2);
+    stream<string[], Error?> csvStream1 = check fileReadCsvAsStream(resourceFilePath1);
+    stream<string[], Error?> csvStream2 = check fileReadCsvAsStream(resourceFilePath2);
     string[][] initialContent = [["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"], ["John Thomson",
     "Software Architect", "WSO2", "38 years", "Colombo"], ["Mary Thompson", "Banker", "Sampath Bank", "30 years",
     "Colombo"]];
@@ -880,7 +880,7 @@ function testFileCsvWriteFromStreamWithAppend() returns Error? {
         test:assertFail(msg = result1.message());
     }
     var result2 = fileReadCsvAsStream(filePath);
-    if (result2 is stream<string[], Error>) {
+    if (result2 is stream<string[], Error?>) {
         int i = 0;
         error? e = result2.forEach(function(string[] val) {
                                int j = 0;
@@ -904,7 +904,7 @@ function testFileCsvWriteFromStreamWithAppend() returns Error? {
         test:assertFail(msg = result3.message());
     }
     var result4 = fileReadCsvAsStream(filePath);
-    if (result4 is stream<string[], Error>) {
+    if (result4 is stream<string[], Error?>) {
         int i = 0;
         error? e = result4.forEach(function(string[] val) {
                                int j = 0;

--- a/io-ballerina/tests/string_io.bal
+++ b/io-ballerina/tests/string_io.bal
@@ -489,8 +489,8 @@ isolated function testFileWriteLinesWithAppend() {
 }
 
 @test:Config {}
-isolated function testFileWriteLinesFromStream() returns Error? {
-    string filePath = TEMP_DIR + "stringContentAsLines2.txt";
+isolated function testFileWriteLinesFromStreamUsingIntermediateFile() returns Error? {
+    string filePath = TEMP_DIR + "stringContentAsLines2_A.txt";
     string resourceFilePath = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
     stream<string, Error?> lineStream = check fileReadLinesAsStream(resourceFilePath);
 
@@ -500,9 +500,9 @@ isolated function testFileWriteLinesFromStream() returns Error? {
     }
 }
 
-@test:Config {dependsOn: [testFileWriteLinesFromStream]}
-function testFileReadLinesAsStream() {
-    string filePath = TEMP_DIR + "stringContentAsLines2.txt";
+@test:Config {dependsOn: [testFileWriteLinesFromStreamUsingIntermediateFile]}
+function testFileReadLinesAsStreamUsingIntermediateFile() {
+    string filePath = TEMP_DIR + "stringContentAsLines2_A.txt";
     string[] expectedLines = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
     var result = fileReadLinesAsStream(filePath);
     if (result is stream<string, error?>) {
@@ -522,8 +522,39 @@ function testFileReadLinesAsStream() {
 }
 
 @test:Config {}
-function testFileWriteLinesFromStreamWithOverwrite() returns Error? {
-    string filePath = TEMP_DIR + "stringContentAsLines2.txt";
+function testFileWriteLinesFromStream() {
+    string filePath = TEMP_DIR + "stringContentAsLines2_B.txt";
+    string[] content = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
+    var result = fileWriteLinesFromStream(filePath, content.toStream());
+    if (result is Error) {
+        test:assertFail(msg = result.message());
+    }
+}
+
+@test:Config {dependsOn: [testFileWriteLinesFromStream]}
+function testFileReadLinesAsStream() {
+    string filePath = TEMP_DIR + "stringContentAsLines2_B.txt";
+    string[] expectedLines = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
+    var result = fileReadLinesAsStream(filePath);
+    if (result is stream<string, Error?>) {
+        int i = 0;
+        error? e = result.forEach(function(string val) {
+                               test:assertEquals(val, expectedLines[i]);
+                               i += 1;
+                           });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 4);
+    } else {
+        test:assertFail(msg = result.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteLinesFromStreamWithOverwriteUsingIntermediateFile() returns Error? {
+    string filePath = TEMP_DIR + "stringContentAsLines2_A.txt";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "stringResourceFile2.txt";
     stream<string, Error?> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
@@ -575,8 +606,8 @@ function testFileWriteLinesFromStreamWithOverwrite() returns Error? {
 }
 
 @test:Config {}
-function testFileWriteLinesFromStreamWithAppend() returns Error? {
-    string filePath = TEMP_DIR + "stringContentAsLines2.txt";
+function testFileWriteLinesFromStreamWithAppendUsingIntermediateFile() returns Error? {
+    string filePath = TEMP_DIR + "stringContentAsLines2_A.txt";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "stringResourceFile2.txt";
     stream<string, Error?> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
@@ -612,6 +643,105 @@ function testFileWriteLinesFromStreamWithAppend() returns Error? {
     }
     var result4 = fileReadLinesAsStream(filePath);
     if (result4 is stream<string, Error?>) {
+        int i = 0;
+        error? e = result4.forEach(function(string val) {
+                               test:assertEquals(val, expectedLines[i]);
+                               i += 1;
+                           });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 9);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteLinesFromStreamWithOverwrite() {
+    string filePath = TEMP_DIR + "stringContentAsLines2_B.txt";
+    string[] content1 = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
+    string[] content2 = ["WSO2", "Google", "Microsoft", "Facebook", "Apple"];
+
+    // Check content 01
+    var result1 = fileWriteLinesFromStream(filePath, content1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadLinesAsStream(filePath);
+    if (result2 is stream<string, error?>) {
+        int i = 0;
+        error? e = result2.forEach(function(string val) {
+                               test:assertEquals(val, content1[i]);
+                               i += 1;
+                           });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 4);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 02
+    var result3 = fileWriteLinesFromStream(filePath, content2.toStream());
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadLinesAsStream(filePath);
+    if (result4 is stream<string, error?>) {
+        int i = 0;
+        error? e = result4.forEach(function(string val) {
+                               test:assertEquals(val, content2[i]);
+                               i += 1;
+                           });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 5);
+    } else {
+        test:assertFail(msg = result4.message());
+    }
+}
+
+@test:Config {}
+function testFileWriteLinesFromStreamWithAppend() {
+    string filePath = TEMP_DIR + "stringContentAsLines2_B.txt";
+    string[] content1 = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
+    string[] content2 = ["WSO2", "Google", "Microsoft", "Facebook", "Apple"];
+    string[] expectedLines = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST",
+                                "WSO2", "Google", "Microsoft", "Facebook", "Apple"];
+    // Check content 01
+    var result1 = fileWriteLinesFromStream(filePath, content1.toStream());
+    if (result1 is Error) {
+        test:assertFail(msg = result1.message());
+    }
+    var result2 = fileReadLinesAsStream(filePath);
+    if (result2 is stream<string, error?>) {
+        int i = 0;
+        error? e = result2.forEach(function(string val) {
+                               test:assertEquals(val, content1[i]);
+                               i += 1;
+                           });
+
+        if (e is error) {
+            test:assertFail(msg = e.message());
+        }
+        test:assertEquals(i, 4);
+    } else {
+        test:assertFail(msg = result2.message());
+    }
+
+    // Check content 01 + 02
+    var result3 = fileWriteLinesFromStream(filePath, content2.toStream(), APPEND);
+    if (result3 is Error) {
+        test:assertFail(msg = result3.message());
+    }
+    var result4 = fileReadLinesAsStream(filePath);
+    if (result4 is stream<string, error?>) {
         int i = 0;
         error? e = result4.forEach(function(string val) {
                                test:assertEquals(val, expectedLines[i]);

--- a/io-ballerina/tests/string_io.bal
+++ b/io-ballerina/tests/string_io.bal
@@ -492,7 +492,7 @@ isolated function testFileWriteLinesWithAppend() {
 isolated function testFileWriteLinesFromStream() returns Error? {
     string filePath = TEMP_DIR + "stringContentAsLines2.txt";
     string resourceFilePath = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
-    stream<string, Error> lineStream = check fileReadLinesAsStream(resourceFilePath);
+    stream<string, Error?> lineStream = check fileReadLinesAsStream(resourceFilePath);
 
     var result = fileWriteLinesFromStream(filePath, lineStream);
     if (result is Error) {
@@ -526,8 +526,8 @@ function testFileWriteLinesFromStreamWithOverwrite() returns Error? {
     string filePath = TEMP_DIR + "stringContentAsLines2.txt";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "stringResourceFile2.txt";
-    stream<string, Error> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
-    stream<string, Error> lineStream2 = check fileReadLinesAsStream(resourceFilePath2);
+    stream<string, Error?> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
+    stream<string, Error?> lineStream2 = check fileReadLinesAsStream(resourceFilePath2);
     string[] content1 = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
     string[] content2 = ["WSO2", "Google", "Microsoft", "Facebook", "Apple"];
 
@@ -537,7 +537,7 @@ function testFileWriteLinesFromStreamWithOverwrite() returns Error? {
         test:assertFail(msg = result1.message());
     }
     var result2 = fileReadLinesAsStream(filePath);
-    if (result2 is stream<string, error?>) {
+    if (result2 is stream<string, Error?>) {
         int i = 0;
         error? e = result2.forEach(function(string val) {
                                test:assertEquals(val, content1[i]);
@@ -558,7 +558,7 @@ function testFileWriteLinesFromStreamWithOverwrite() returns Error? {
         test:assertFail(msg = result3.message());
     }
     var result4 = fileReadLinesAsStream(filePath);
-    if (result4 is stream<string, error?>) {
+    if (result4 is stream<string, Error?>) {
         int i = 0;
         error? e = result4.forEach(function(string val) {
                                test:assertEquals(val, content2[i]);
@@ -579,8 +579,8 @@ function testFileWriteLinesFromStreamWithAppend() returns Error? {
     string filePath = TEMP_DIR + "stringContentAsLines2.txt";
     string resourceFilePath1 = TEST_RESOURCE_PATH + "stringResourceFile1.txt";
     string resourceFilePath2 = TEST_RESOURCE_PATH + "stringResourceFile2.txt";
-    stream<string, Error> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
-    stream<string, Error> lineStream2 = check fileReadLinesAsStream(resourceFilePath2);
+    stream<string, Error?> lineStream1 = check fileReadLinesAsStream(resourceFilePath1);
+    stream<string, Error?> lineStream2 = check fileReadLinesAsStream(resourceFilePath2);
     string[] initialContent = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"];
     string[] expectedLines = ["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST",
                                 "WSO2", "Google", "Microsoft", "Facebook", "Apple"];
@@ -590,7 +590,7 @@ function testFileWriteLinesFromStreamWithAppend() returns Error? {
         test:assertFail(msg = result1.message());
     }
     var result2 = fileReadLinesAsStream(filePath);
-    if (result2 is stream<string, error?>) {
+    if (result2 is stream<string, Error?>) {
         int i = 0;
         error? e = result2.forEach(function(string val) {
                                test:assertEquals(val, initialContent[i]);
@@ -611,7 +611,7 @@ function testFileWriteLinesFromStreamWithAppend() returns Error? {
         test:assertFail(msg = result3.message());
     }
     var result4 = fileReadLinesAsStream(filePath);
-    if (result4 is stream<string, error?>) {
+    if (result4 is stream<string, Error?>) {
         int i = 0;
         error? e = result4.forEach(function(string val) {
                                test:assertEquals(val, expectedLines[i]);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1181

## Approach
- Introduce nil completion to the I/O streams(lines, blocks, and CSV)
- Restore the previous `arr.toStream()` related tests

## Automation tests
 - Unit tests 
   > Yes


## Test environment
- macOS
- Java 11
- SLAlpha 4