### PR TITLE
Add Ballerina publish to central workflow

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,0 +1,29 @@
+name: Publish to the Ballerina central
+
+on:
+    workflow_dispatch:
+
+jobs:
+    publish-release:
+        runs-on: ubuntu-latest
+        if: github.repository_owner == 'ballerina-platform'
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Set up JDK 11
+                uses: actions/setup-java@v1
+                with:
+                    java-version: 11
+            -   name: Set version env variable
+                run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
+            -   name: Publish artifact
+                env:
+                    BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+                    packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                    packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                    GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                    publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                    publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                run: |
+                    ./gradlew ballerinaPublish

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -13,8 +13,6 @@ jobs:
                 uses: actions/setup-java@v1
                 with:
                     java-version: 11
-            -   name: Set version env variable
-                run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
             -   name: Publish artifact
@@ -23,7 +21,5 @@ jobs:
                     packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                     GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                    publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                    publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
                     ./gradlew ballerinaPublish


### PR DESCRIPTION
## Purpose
To publish artifacts to Ballerina central if something went wrong in the release pipeline.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
