### PR TITLE
Fix the Ballerina.toml updating before the Ballerina push

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Execute the commands below to build from source.
    ./gradlew clean build -PbalJavaDebug=<port>
    ./gradlew clean test -PbalJavaDebug=<port>
    ```
+1. Publish ZIP artifact to the local `.m2` repository:
+   ```
+   ./gradlew clean build publishToMavenLocal
+   ```
+1. Publish the generated artifacts to the local Ballerina central repository:
+   ```
+   ./gradlew clean build -PpublishToLocalCentral=true
+   ```
+
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -150,9 +150,7 @@ task ballerinaBuild {
                     commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
                 }
             }
-        }
-
-        if (needBuildWithTest) {
+        } else if (needBuildWithTest) {
             exec {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -92,6 +92,9 @@ def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
 def testParams = ""
+def needSeparateTest = false
+def needBuildWithTest = false
+def needPublishToCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -109,36 +112,27 @@ task initializeVariables {
 
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
-                graph.hasTask(":${packageName}-ballerina:publishToMavenLocal"))  {
-            ballerinaTest.enabled = false
+                graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
+            needSeparateTest = false
+
+            if (graph.hasTask(":${packageName}-ballerina:build")) {
+                needBuildWithTest = true
+            }
+            if (graph.hasTask(":${packageName}-ballerina:publish")) {
+                needBuildWithTest = true
+                needPublishToCentral = true
+            }
+            if (graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
+                needBuildWithTest = true
+            }
         } else {
-            ballerinaTest.enabled = true
+            needSeparateTest = true
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
             testParams = "--code-coverage --includes=*"
         } else {
             testParams = "--skip-tests"
-        }
-
-        if (graph.hasTask(":${packageName}-ballerina:publish")) {
-            ballerinaPublish.enabled = true
-        } else {
-            ballerinaPublish.enabled = false
-        }
-    }
-}
-
-task ballerinaTest {
-    doLast {
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
-            }
         }
     }
 }
@@ -147,73 +141,83 @@ task ballerinaBuild {
     inputs.dir file(project.projectDir)
 
     doLast {
-        // Build and populate caches
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build -c ${testParams} ${debugParams}"
+        if (needSeparateTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
+                }
             }
-        }
-        // extract bala file to artifact cache directory
-        file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
-            copy {
-                from zipTree(balaFile)
-                into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
-            }
-        }
-        copy {
-            from file("${project.projectDir}/target/cache")
-            exclude '**/*-testable.jar'
-            exclude '**/tests_cache/'
-            into file("${artifactCacheParent}/cache/")
         }
 
-        // Doc creation and packing
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat doc && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "${distributionBinPath}/bal doc"
+        if (needBuildWithTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build -c ${testParams} ${debugParams}"
+                }
+            }
+            // extract bala file to artifact cache directory
+            file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+                copy {
+                    from zipTree(balaFile)
+                    into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                }
+            }
+            copy {
+                from file("${project.projectDir}/target/cache")
+                exclude '**/*-testable.jar'
+                exclude '**/tests_cache/'
+                into file("${artifactCacheParent}/cache/")
+            }
+
+            // Doc creation and packing
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat doc && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${distributionBinPath}/bal doc"
+                }
+            }
+            copy {
+                from file("${project.projectDir}/target/apidocs/${packageName}")
+                into file("${project.projectDir}/build/docs_parent/docs/${packageName}")
             }
         }
-        copy {
-            from file("${project.projectDir}/target/apidocs/${packageName}")
-            into file("${project.projectDir}/build/docs_parent/docs/${packageName}")
+
+        if (needPublishToCentral) {
+            if (project.version.endsWith('-SNAPSHOT') ||
+                    project.version.matches(timestampedVersionRegex)) {
+                return
+            }
+            if (ballerinaCentralAccessToken != null) {
+                println("Publishing to the ballerina central..")
+                exec {
+                    workingDir project.projectDir
+                    environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                    } else {
+                        commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                    }
+                }
+            } else {
+                throw new InvalidUserDataException("Central Access Token is not present")
+            }
         }
-        ballerinaConfigFile.text = originalConfig
     }
 
     outputs.dir artifactCacheParent
     outputs.dir artifactBallerinaDocs
     outputs.dir artifactLibParent
-}
-
-task ballerinaPublish {
-    doLast {
-        if (project.version.endsWith('-SNAPSHOT') ||
-                project.version.matches(timestampedVersionRegex)) {
-            return
-        }
-        if (ballerinaCentralAccessToken != null) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-        } else {
-            throw new InvalidUserDataException("Central Access Token is not present")
-        }
-    }
 }
 
 task createArtifactZip(type: Zip) {
@@ -240,16 +244,6 @@ publishing {
     }
 }
 
-ballerinaTest.dependsOn ":${packageName}-native:build"
-ballerinaTest.dependsOn ":${packageName}-native:test"
-ballerinaTest.dependsOn ":${packageName}-test-utils:build"
-ballerinaTest.dependsOn unpackJballerinaTools
-ballerinaTest.dependsOn updateTomlFile
-ballerinaTest.dependsOn initializeVariables
-ballerinaTest.finalizedBy revertTomlFile
-test.dependsOn ballerinaTest
-
-ballerinaBuild.dependsOn test
 ballerinaBuild.dependsOn ":${packageName}-native:build"
 ballerinaBuild.dependsOn ":${packageName}-native:test"
 ballerinaBuild.dependsOn ":${packageName}-test-utils:build"
@@ -257,14 +251,7 @@ ballerinaBuild.dependsOn unpackJballerinaTools
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn updateTomlFile
 ballerinaBuild.finalizedBy revertTomlFile
+test.dependsOn ballerinaBuild
 build.dependsOn ballerinaBuild
-
-ballerinaPublish.dependsOn ":${packageName}-native:test"
-ballerinaPublish.dependsOn ":${packageName}-test-utils:build"
-ballerinaPublish.dependsOn ":${packageName}-native:build"
-ballerinaPublish.dependsOn ballerinaBuild
-ballerinaPublish.dependsOn updateTomlFile
-ballerinaPublish.dependsOn initializeVariables
-ballerinaPublish.finalizedBy revertTomlFile
-publish.dependsOn ballerinaPublish
-
+publishToMavenLocal.dependsOn build
+publish.dependsOn build

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -95,6 +95,7 @@ def testParams = ""
 def needSeparateTest = false
 def needBuildWithTest = false
 def needPublishToCentral = false
+def needPublishToLocalCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -108,6 +109,9 @@ task initializeVariables {
     }
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
+    }
+    if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
+        needPublishToLocalCentral = true
     }
 
     gradle.taskGraph.whenReady { graph ->
@@ -211,6 +215,17 @@ task ballerinaBuild {
                 }
             } else {
                 throw new InvalidUserDataException("Central Access Token is not present")
+            }
+        } else if (needPublishToLocalCentral) {
+            println("Publishing to the ballerina local central repository..")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%% --repository=local"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal push --repository=local"
+                }
             }
         }
     }

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -117,17 +117,11 @@ task initializeVariables {
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
                 graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-            needSeparateTest = false
 
-            if (graph.hasTask(":${packageName}-ballerina:build")) {
-                needBuildWithTest = true
-            }
+            needSeparateTest = false
+            needBuildWithTest = true
             if (graph.hasTask(":${packageName}-ballerina:publish")) {
-                needBuildWithTest = true
                 needPublishToCentral = true
-            }
-            if (graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-                needBuildWithTest = true
             }
         } else {
             needSeparateTest = true


### PR DESCRIPTION
## Purpose

Incorporate all tests, build, and push into one task.
Then, we don't need to repetitively run update TOML and revert TOML tasks; running those two once will be enough.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1247
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
