### PR TITLE
Enable a parameter to indicate publish only to central

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -22,4 +22,4 @@ jobs:
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                     GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
-                    ./gradlew ballerinaPublish
+                    ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Execute the commands below to build from source.
    ```
    ./gradlew clean build -PpublishToLocalCentral=true
    ```
+1. Publish the generated artifacts to the Ballerina central repository:
+   ```
+   ./gradlew clean build -PpublishToCentral=true
+   ```
 
 ## Contributing to Ballerina
 

--- a/io-ballerina/build.gradle
+++ b/io-ballerina/build.gradle
@@ -114,6 +114,9 @@ task initializeVariables {
     if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
         needPublishToLocalCentral = true
     }
+    if (project.hasProperty("publishToCentral") && (project.findProperty("publishToCentral") == "true")) {
+        needPublishToCentral = true
+    }
 
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||


### PR DESCRIPTION
## Purpose
Enabling `-PpublishToCentral=true` will only publish artifacts to the Ballerina central without publishing to Github.
This could be useful when something goes wrong in central publishing.

Related to https://github.com/ballerina-platform/module-ballerina-io/pull/133

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
