### PR TITLE
Fix the parameter order

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=0.6.0-beta.1-SNAPSHOT
-ballerinaLangVersion=2.0.0-beta.1-20210503-234400-f5ab2412
+ballerinaLangVersion=2.0.0-beta.1-20210504-134400-67794dfe
 puppycrawlCheckstyleVersion=8.18
 testngVersion=6.14.3
 slf4jVersion=1.7.30

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -101,10 +101,10 @@ Error? {
 # io:Error? result = io:fileWriteLinesFromStream("./resources/myfile.txt", lineStream);
 # ```
 # + path - The path of the file
-# + lineStream -  A stream of lines to write
+# + lineStream - A stream of lines to write
 # + option - To indicate whether to overwrite or append the given content
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error?> lineStream,
+public isolated function fileWriteLinesFromStream(@untainted string path, stream<string, Error?> lineStream, 
                                                   FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteLinesFromStream(check openWritableFile(path, option), lineStream);
 }
@@ -131,8 +131,8 @@ public isolated function fileWriteJson(@untainted string path, json content) ret
 # + xmlOptions - XML writing options(XML entity type and DOCTYPE)
 # + fileWriteOption - file write option(`OVERWRITE` and `APPEND` are the possible values, and the default value is `OVERWRITE`)
 # + return - The null `()` value when the writing was successful or an `io:Error`
-public isolated function fileWriteXml(@untainted string path, xml content, *XmlWriteOptions xmlOptions, FileWriteOption fileWriteOption = 
-                                      OVERWRITE) returns Error? {
+public isolated function fileWriteXml(@untainted string path, xml content, FileWriteOption fileWriteOption = OVERWRITE, 
+                                      *XmlWriteOptions xmlOptions) returns Error? {
     WritableByteChannel byteChannel;
     if (xmlOptions.xmlEntityType == DOCUMENT_ENTITY) {
         if (fileWriteOption == APPEND) {


### PR DESCRIPTION
## Purpose
As per the spec, the defaultable params should come before included-params.
Related to this https://github.com/ballerina-platform/ballerina-lang/issues/27818

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
