### PR TITLE
Fix the unexpected error return by introducing package specific errors

### DIFF
--- a/io-ballerina/tests/json_io.bal
+++ b/io-ballerina/tests/json_io.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/test;
 
 @test:Config {}
@@ -120,7 +119,10 @@ isolated function testFileWriteJsonWithTruncate() {
                 "fileServlet": "/static/*",
                 "cofaxTools": ["/tools1/*", "/tools2/*", "/tools3/*"]
             }}};
-    json content2 = {"userName": "Harry Thompson", "age": 23};
+    json content2 = {
+        "userName": "Harry Thompson",
+        "age": 23
+    };
 
     // Check content 01
     var result1 = fileWriteJson(filePath, content1);
@@ -139,7 +141,7 @@ isolated function testFileWriteJsonWithTruncate() {
     if (result3 is Error) {
         test:assertFail(msg = result3.message());
     }
-    var result4= fileReadJson(filePath);
+    var result4 = fileReadJson(filePath);
     if (result4 is json) {
         test:assertEquals(result4, content2);
     } else {
@@ -189,5 +191,22 @@ isolated function testReadHigherUnicodeJson() {
         }
     } else {
         test:assertFail(msg = byteChannel.message());
+    }
+}
+
+@test:Config {}
+isolated function testReadInvalidJsonFile() {
+    string filePath = TEMP_DIR + "invalidJsonFile.json";
+    string content = "{ stuff:";
+
+    var writeResult = fileWriteString(filePath, content);
+    if (writeResult is Error) {
+        test:assertFail(msg = writeResult.message());
+    }
+    json|Error readResult = fileReadJson(filePath);
+    if (readResult is json) {
+        test:assertFail("Expected io:Error not found");
+    } else {
+        test:assertEquals(readResult.message(), "expected \" or } at line: 1 column: 3");
     }
 }

--- a/io-ballerina/tests/xml_io.bal
+++ b/io-ballerina/tests/xml_io.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 import ballerina/test;
+import ballerina/lang.'string as langstring;
 
 @test:Config {}
 isolated function testWriteXml() {
@@ -244,7 +245,7 @@ isolated function testFileWriteDocTypedXml() {
 
     xml content = checkpanic fileReadXml(originalFilePath);
     string doctypeValue = "<!DOCTYPE note SYSTEM \"Note.dtd\">";
-    var writeResult = fileWriteXml(filePath, content, doctype={system:"Note.dtd"});
+    var writeResult = fileWriteXml(filePath, content, doctype = {system: "Note.dtd"});
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
@@ -275,7 +276,7 @@ isolated function testFileWriteDocTypedWithAppend() {
     string originalFilePath = "tests/resources/originalXmlContent.xml";
 
     xml content = checkpanic fileReadXml(originalFilePath);
-    var writeResult = fileWriteXml(filePath, content, fileWriteOption=APPEND);
+    var writeResult = fileWriteXml(filePath, content, fileWriteOption = APPEND);
     if (writeResult is Error) {
         test:assertEquals(writeResult.message(), "The file append operation is not allowed for Document Entity");
     } else {
@@ -295,7 +296,8 @@ isolated function testFileAppendDocTypedXml() {
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
-    var appendResult = fileWriteXml(filePath, content2, fileWriteOption=APPEND, xmlEntityType=EXTERNAL_PARSED_ENTITY);
+    var appendResult = 
+    fileWriteXml(filePath, content2, fileWriteOption = APPEND, xmlEntityType = EXTERNAL_PARSED_ENTITY);
     if (appendResult is Error) {
         test:assertFail(msg = appendResult.message());
     }
@@ -320,7 +322,7 @@ isolated function testFileWriteDocTypedXmlWithInternalSubset() {
         <!ELEMENT heading (#PCDATA)>
         <!ELEMENT body (#PCDATA)>
     ]`;
-    var writeResult = fileWriteXml(filePath, content, doctype={internalSubset: internalSub});
+    var writeResult = fileWriteXml(filePath, content, doctype = {internalSubset: internalSub});
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
@@ -346,7 +348,10 @@ isolated function testFileWriteDocTypedXmlWithPrioritizeInternalSubset() {
         <!ELEMENT heading (#PCDATA)>
         <!ELEMENT body (#PCDATA)>
     ]`;
-    var writeResult = fileWriteXml(filePath, content, doctype={internalSubset: internalSub, system: systemId});
+    var writeResult = fileWriteXml(filePath, content, doctype = {
+        internalSubset: internalSub,
+        system: systemId
+    });
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
@@ -365,11 +370,32 @@ isolated function testFileWriteDocTypedXmlWithPublic() {
     string doctypeValue = "<!DOCTYPE note PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">";
     string publicId = "-//W3C//DTD HTML 4.01 Transitional//EN";
     string systemId = "http://www.w3.org/TR/html4/loose.dtd";
-    var writeResult = fileWriteXml(filePath, content, doctype={system: systemId, 'public: publicId});
+    var writeResult = fileWriteXml(filePath, content, doctype = {
+        system: systemId,
+        'public: publicId
+    });
     if (writeResult is Error) {
         test:assertFail(msg = writeResult.message());
     }
     string readResult = checkpanic fileReadString(filePath);
     string expectedResult = checkpanic fileReadString(resultFilePath);
     test:assertEquals(readResult, expectedResult);
+}
+
+@test:Config {}
+isolated function testReadInvalidXmlFile() {
+    string filePath = TEMP_DIR + "invalidXmlFile.json";
+    string content = "{ stuff:";
+
+    var writeResult = fileWriteString(filePath, content);
+    if (writeResult is Error) {
+        test:assertFail(msg = writeResult.message());
+    }
+    xml|Error readResult = fileReadXml(filePath);
+    if (readResult is xml) {
+        test:assertFail("Expected io:Error not found");
+    } else {
+        test:assertTrue(langstring:includes(readResult.message(), 
+        "failed to create xml: Unexpected character '{' (code 123) in prolog; expected '<", 0));
+    }
 }

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/utils/IOUtils.java
@@ -58,8 +58,7 @@ public class IOUtils {
      * @return an error which will be propagated to ballerina user
      */
     public static BError createError(String errorMsg) {
-        return ErrorCreator.createDistinctError(GenericError.errorCode(), getIOPackage(),
-                                                StringUtils.fromString(errorMsg));
+        return createError(GenericError, errorMsg);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Previously, when there is an unidentified error, the I/O package returned an `error`. With this fix, it will return an `io:GenericError` which is a sub type of `io:Error`.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1316

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
