### PR TITLE
Include the terminating carriage information into the file string reading APIs docs

### DIFF
--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 # Reads the entire file content as a `string`.
+# The resulting string output does not contain the terminal carriage(e.g. `\r` or `\n`).
 # ```ballerina
 # string|io:Error content = io:fileReadString("./resources/myfile.txt");
 # ```
@@ -25,6 +26,7 @@ public isolated function fileReadString(@untainted string path) returns @tainted
 }
 
 # Reads the entire file content as a list of lines.
+# The resulting string array does not contain the terminal carriage(e.g. `\r` or `\n`).
 # ```ballerina
 # string[]|io:Error content = io:fileReadLines("./resources/myfile.txt");
 # ```
@@ -35,6 +37,7 @@ public isolated function fileReadLines(@untainted string path) returns @tainted 
 }
 
 # Reads file content as a stream of lines.
+# The resulting stream does not contain the terminal carriage(e.g. `\r` or `\n`).
 # ```ballerina
 # stream<string, io:Error?>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
 # ```

--- a/io-ballerina/file_string_io.bal
+++ b/io-ballerina/file_string_io.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 # Reads the entire file content as a `string`.
-# The resulting string output does not contain the terminal carriage(e.g. `\r` or `\n`).
+# The resulting string output does not contain the terminal carriage (e.g., `\r` or `\n`).
 # ```ballerina
 # string|io:Error content = io:fileReadString("./resources/myfile.txt");
 # ```
@@ -26,7 +26,7 @@ public isolated function fileReadString(@untainted string path) returns @tainted
 }
 
 # Reads the entire file content as a list of lines.
-# The resulting string array does not contain the terminal carriage(e.g. `\r` or `\n`).
+# The resulting string array does not contain the terminal carriage (e.g., `\r` or `\n`).
 # ```ballerina
 # string[]|io:Error content = io:fileReadLines("./resources/myfile.txt");
 # ```
@@ -37,7 +37,7 @@ public isolated function fileReadLines(@untainted string path) returns @tainted 
 }
 
 # Reads file content as a stream of lines.
-# The resulting stream does not contain the terminal carriage(e.g. `\r` or `\n`).
+# The resulting stream does not contain the terminal carriage (e.g., `\r` or `\n`).
 # ```ballerina
 # stream<string, io:Error?>|io:Error content = io:fileReadLinesAsStream("./resources/myfile.txt");
 # ```


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1393

## Examples

### Text file
Note the new line at the end.
```
The Big Bang Theory
F.R.I.E.N.D.S
Game of Thrones
LOST

```

### Ballerina program
```
import ballerina/io;

public function main() returns error? {
    io:println(check io:fileReadString("textfile.txt"));
}
```

### Output 
Output is not as follows with a terminating carriage.
```
["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST", "\n"]
```

Ballerina output is an array without terminating carriage.
```
["The Big Bang Theory", "F.R.I.E.N.D.S", "Game of Thrones", "LOST"]
```
## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
