### PR TITLE
Add newline replacement for platform-specific line separator

### DIFF
--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
@@ -129,11 +129,11 @@ public class CharacterChannelUtils {
             for (int i = 0; i < lines.length; i++) {
                 joiner.add(lines[i]);
             }
-            return io.ballerina.runtime.api.utils.StringUtils.fromString(joiner.toString());
+            return io.ballerina.runtime.api.utils.StringUtils.fromString(joiner.toString()
+                    .replaceAll(System.lineSeparator(), "\n"));
         } catch (UncheckedIOException | BError e) {
             return IOUtils.createError(e);
         }
-
     }
 
     public static Object readJson(BObject channel) {

--- a/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
+++ b/io-native/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
@@ -129,7 +129,7 @@ public class CharacterChannelUtils {
             for (int i = 0; i < lines.length; i++) {
                 joiner.add(lines[i]);
             }
-            return io.ballerina.runtime.api.utils.StringUtils.fromString(joiner.toString()
+            return StringUtils.fromString(joiner.toString()
                     .replaceAll(System.lineSeparator(), "\n"));
         } catch (UncheckedIOException | BError e) {
             return IOUtils.createError(e);
@@ -145,7 +145,7 @@ public class CharacterChannelUtils {
                     JsonUtils.NonStringValueProcessingMode.FROM_JSON_STRING);
             if (returnValue instanceof String) {
 
-                return io.ballerina.runtime.api.utils.StringUtils.fromString((String) returnValue);
+                return StringUtils.fromString((String) returnValue);
             }
             return returnValue;
         } catch (BError e) {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1392

Line separators for main operating systems are changed as follows:
- Unix based OS(Linux/MacOS): `\n` -> `\n`
- Windows: `\r\n` -> `\n`

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
