### PR TITLE
Add Names for Workflow Jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   ubuntu-build:
+    name: Build on Ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -23,6 +24,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   windows-build:
+    name: Build on Windows
     runs-on: windows-latest
 
     steps:

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -98,6 +98,7 @@ updateTomlFiles.dependsOn unpackJballerinaTools
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-native:test"
 test.dependsOn ":${packageName}-test-utils:build"
+build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-native:test"
 build.dependsOn ":${packageName}-test-utils:build"


### PR DESCRIPTION
## Purpose
This PR will add names to pull request workflow jobs `Build on Ubuntu` and `Build on Windows. These two jobs will be added as required checks for a PR to merge.

Releated issue: [#1674](https://github.com/ballerina-platform/ballerina-standard-library/issues/1674)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
