### PR TITLE
Use direct coping of CSV file due to config map limits

### DIFF
--- a/load-tests/csv_processor/src/Cloud.toml
+++ b/load-tests/csv_processor/src/Cloud.toml
@@ -12,6 +12,6 @@ max_cpu="1000m"
 min_replicas=1
 max_replicas=1
 
-[[cloud.config.maps]]
-file="./resources/ghz_output.csv"
-mount_path="/home/ballerina/resources/ghz_output.csv"
+[[container.copy.files]]
+sourceFile="./resources/ghz_output.csv"
+target="/home/ballerina/resources/ghz_output.csv"


### PR DESCRIPTION

## Purpose
K8s config maps can only hold up to 1MB. So, we have to use direct copying to the container instead of using a config map.

Related to - https://github.com/ballerina-platform/ballerina-performance-cloud/issues/3178

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
