### PR TITLE
Reduce users and increase duration to find the threshold values

### DIFF
--- a/load-tests/csv_processor/scripts/run.sh
+++ b/load-tests/csv_processor/scripts/run.sh
@@ -19,4 +19,4 @@
 set -e
 source base-scenario.sh
 
-jmeter -n -t "$scriptsDir/"http-get-request.jmx -l "$resultsDir/"original.jtl -Jusers=20 -Jduration=1200 -Jhost=bal.perf.test -Jport=80 -Jprotocol=http -Jpath=BalPerformance/grpc $payload_flags
+jmeter -n -t "$scriptsDir/"http-get-request.jmx -l "$resultsDir/"original.jtl -Jusers=10 -Jduration=3600 -Jhost=bal.perf.test -Jport=80 -Jprotocol=http -Jpath=BalPerformance/grpc $payload_flags


### PR DESCRIPTION


## Purpose
Even auth tests run with 10 users, need to try that value.
For 20 users and 1200 duration, the error rate is 57.54%
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
