### PR TITLE
Disable observability

### DIFF
--- a/examples/bow/Ballerina.toml
+++ b/examples/bow/Ballerina.toml
@@ -2,4 +2,4 @@
 distribution = "2201.0.0-20211221-194900-b414ea8e"
 
 [build-options]
-observabilityIncluded = true
+observabilityIncluded = false

--- a/examples/csv_processor/Ballerina.toml
+++ b/examples/csv_processor/Ballerina.toml
@@ -2,4 +2,4 @@
 distribution = "slbeta5"
 
 [build-options]
-observabilityIncluded = true
+observabilityIncluded = false


### PR DESCRIPTION
## Purpose
Since we removed the observability modules from the ballerina-lang repo we have to disable the `observabilityIncluded` flag

## Related Issues
https://github.com/ballerina-platform/ballerina-lang/issues/33195

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
