### PR TITLE
Remove the ZIP URL in the load test trigger action

### DIFF
--- a/.github/workflows/trigger-load-tests.yml
+++ b/.github/workflows/trigger-load-tests.yml
@@ -54,4 +54,4 @@ jobs:
           repo: ballerina-platform/ballerina-performance-cloud
           ref: refs/heads/main
           token: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          inputs: '{ "repo-name": "module-ballerina-io", "tests": "${{ steps.formatTestNames.outputs.testNames }}", "zipURL": ${{ steps.setRuntimeUrl.outputs.runtimeUrl}}, "clusterName": "${{ github.event.inputs.clusterName }}", "dispatchType": "${{ github.event.inputs.dispatchType }}" }'
+          inputs: '{ "repo-name": "module-ballerina-io", "tests": "${{ steps.formatTestNames.outputs.testNames }}", "clusterName": "${{ github.event.inputs.clusterName }}", "dispatchType": "${{ github.event.inputs.dispatchType }}" }'


### PR DESCRIPTION


## Purpose
This load test cannot run using the intermediate pack, which create in the I/O module since the load test needs HTTP to run. So, we have to use the nightly distribution.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
