### PR TITLE
Allow central publish action to publish to multiple environments

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -2,6 +2,15 @@ name: Publish to the Ballerina central
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Select environment
+        required: true
+        options:
+          - CENTRAL
+          - DEV CENTRAL
+          - STAGE CENTRAL
 
 jobs:
   publish-release:
@@ -29,9 +38,35 @@ jobs:
           scan-ref: '/github/workspace/ballerina/lib'
           format: 'table'
           exit-code: '1'
-      - name: Publish artifact
+      - name: Ballerina Central Push
+        if: ${{ github.event.inputs.environment == 'CENTRAL' }}
         env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: false
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean build -PpublishToCentral=true
+
+      - name: Ballerina Central Dev Push
+        if: ${{ github.event.inputs.environment == 'DEV CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_STAGE_CENTRAL: false
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew clean build -PpublishToCentral=true
+      - name: Ballerina Central Stage Push
+        if: ${{ github.event.inputs.environment == 'STAGE CENTRAL' }}
+        env:
+          BALLERINA_DEV_CENTRAL: false
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}


### PR DESCRIPTION
## Purpose
Related to [3136](https://github.com/ballerina-platform/ballerina-standard-library/issues/3136)
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
