### PR TITLE
Update `fileWriteCsvFromStream` to maintain the order while writing

### DIFF
--- a/ballerina/channel_csv_io.bal
+++ b/ballerina/channel_csv_io.bal
@@ -65,7 +65,7 @@ Error? {
     if csvStreamToWrite is stream<string[], Error?> {
         WritableCSVChannel csvChannel = check getWritableCSVChannel(check openWritableCsvFile(path, option = option));
         do {
-            record {|string[] value;|}|Error? csvRecordString = csvStreamToWrite.next();
+            record {|string[] value;|}|Error? csvRecordString = check csvStreamToWrite.next();
             while csvRecordString is record {|string[] value;|} {
                 check csvChannel.write(csvRecordString.value);
                 csvRecordString = csvStreamToWrite.next();
@@ -109,8 +109,8 @@ Error? {
                 foreach string header in headersFromStream {
                     sValues.push(csvRecordMap["value"].get(header).toString());
                 }
-                csvRecordMap = check csvStreamToWrite.next();
                 check csvChannel.write(sValues);
+                csvRecordMap = check csvStreamToWrite.next();
             }
         } on fail Error err {
             check csvChannel.close();

--- a/ballerina/channel_csv_io.bal
+++ b/ballerina/channel_csv_io.bal
@@ -79,12 +79,10 @@ Error? {
     } else if csvStreamToWrite is stream<map<anydata>, Error?> {
         boolean skipHeaders = false;
         string[] headersFromStream;
-        WritableCSVChannel csvChannel = check getWritableCSVChannel(check openWritableCsvFile(path, option = option));
         record {|map<anydata> value;|}|Error? csvRecordMap = csvStreamToWrite.next();
         if (csvRecordMap is record {|map<anydata> value;|}) {
             headersFromStream = csvRecordMap["value"].keys();
         } else {
-            check csvChannel.close();
             check csvStreamToWrite.close();
             return;
         }
@@ -96,6 +94,7 @@ Error? {
                 headersFromStream = headersFromCSV;
             }
         }
+        WritableCSVChannel csvChannel = check getWritableCSVChannel(check openWritableCsvFile(path, option = option));
         do {
             if !skipHeaders {
                 check csvChannel.write(headersFromStream);

--- a/ballerina/channel_csv_io.bal
+++ b/ballerina/channel_csv_io.bal
@@ -80,16 +80,10 @@ Error? {
         boolean skipHeaders = false;
         string[] headersFromStream;
         record {|map<anydata> value;|}? csvRecordMap = check csvStreamToWrite.next();
-        do {
-            if csvRecordMap !is () {
-                headersFromStream = csvRecordMap["value"].keys();
-            } else {
-                check csvStreamToWrite.close();
-                return;
-            }
-        } on fail Error err {
-            check csvStreamToWrite.close();
-            return err;
+        if csvRecordMap !is () {
+            headersFromStream = csvRecordMap["value"].keys();
+        } else {
+            return;
         }
         if option == APPEND {
             string[] headersFromCSV = check readHeadersFromCsvFile(path);

--- a/ballerina/channel_csv_io.bal
+++ b/ballerina/channel_csv_io.bal
@@ -108,6 +108,7 @@ Error? {
                 check csvChannel.write(sValues);
             }
         } on fail Error err {
+            check csvChannel.close();
             check csvStreamToWrite.close();
             return err;
         }

--- a/ballerina/file_csv_io.bal
+++ b/ballerina/file_csv_io.bal
@@ -24,7 +24,7 @@ import ballerina/jballerina.java;
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
 # + returnType - The type of the return value (string[] or map<anydata>)
 # + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
-public isolated function fileReadCsv(string path, int skipHeaders = 0, typedesc<string[]|map<anydata>> returnType = <>) returns returnType[]|Error = @java:Method{
+public isolated function fileReadCsv(string path, int skipHeaders = 0, typedesc<string[]|map<anydata>> returnType = <>) returns returnType[]|Error = @java:Method {
     name: "fileReadCsv",
     'class: "io.ballerina.stdlib.io.nativeimpl.CsvChannelUtils"
 } external;
@@ -37,7 +37,7 @@ public isolated function fileReadCsv(string path, int skipHeaders = 0, typedesc<
 # + path - The CSV file path
 # + returnType - The type of the return value (string[] or map<anydata>)
 # + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
-public isolated function fileReadCsvAsStream(string path, typedesc<string[]|map<anydata>> returnType = <>) returns stream<returnType, Error?>|Error = @java:Method{
+public isolated function fileReadCsvAsStream(string path, typedesc<string[]|map<anydata>> returnType = <>) returns stream<returnType, Error?>|Error = @java:Method {
     name: "createCsvAsStream",
     'class: "io.ballerina.stdlib.io.nativeimpl.CsvChannelUtils"
 } external;
@@ -68,6 +68,6 @@ Error? {
 # + option - To indicate whether to overwrite or append the given content
 # + return - `()` when the writing was successful or an `io:Error`
 public isolated function fileWriteCsvFromStream(string path, stream<string[]|map<anydata>, Error?> content,
-                                                FileWriteOption option = OVERWRITE) returns Error? {
+        FileWriteOption option = OVERWRITE) returns Error? {
     return channelWriteCsvFromStream(path, option, content);
 }

--- a/ballerina/file_csv_io.bal
+++ b/ballerina/file_csv_io.bal
@@ -69,5 +69,5 @@ Error? {
 # + return - `()` when the writing was successful or an `io:Error`
 public isolated function fileWriteCsvFromStream(string path, stream<string[]|map<anydata>, Error?> content,
                                                 FileWriteOption option = OVERWRITE) returns Error? {
-    return channelWriteCsvFromStream(check openWritableCsvFile(path, option = option), content);
+    return channelWriteCsvFromStream(path, option, content);
 }

--- a/ballerina/file_csv_io.bal
+++ b/ballerina/file_csv_io.bal
@@ -18,12 +18,12 @@ import ballerina/jballerina.java;
 # Read file content as a CSV.
 # ```ballerina
 # string[][]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
-# map<anydata>[]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
+# record[]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
-# + returnType - The type of the return value (string[] or map<anydata>)
-# + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
+# + returnType - The type of the return value (string[] or a Ballerina record)
+# + return - The entire CSV content in the channel as an array of string arrays, array of Ballerina records or an `io:Error`
 public isolated function fileReadCsv(string path, int skipHeaders = 0, typedesc<string[]|map<anydata>> returnType = <>) returns returnType[]|Error = @java:Method {
     name: "fileReadCsv",
     'class: "io.ballerina.stdlib.io.nativeimpl.CsvChannelUtils"
@@ -32,11 +32,11 @@ public isolated function fileReadCsv(string path, int skipHeaders = 0, typedesc<
 # Read file content as a CSV.
 # ```ballerina
 # stream<string[]|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
-# stream<map<anydata>, io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
+# stream<record, io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
-# + returnType - The type of the return value (string[] or map<anydata>)
-# + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
+# + returnType - The type of the return value (string[] or a Ballerina record)
+# + return - The entire CSV content in the channel a stream of string arrays, Ballerina records or an `io:Error`
 public isolated function fileReadCsvAsStream(string path, typedesc<string[]|map<anydata>> returnType = <>) returns stream<returnType, Error?>|Error = @java:Method {
     name: "createCsvAsStream",
     'class: "io.ballerina.stdlib.io.nativeimpl.CsvChannelUtils"
@@ -45,11 +45,14 @@ public isolated function fileReadCsvAsStream(string path, typedesc<string[]|map<
 # Write CSV content to a file.
 # If the input is of `record{}[]` type, the field names of the record{} are written as headers to the file. Additionally if the CSV contains data records, the header is used to identify the order of the values.
 # ```ballerina
+# type Coord record {int x;int y;};
+# Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]
 # string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
 # io:Error? result = io:fileWriteCsv("./resources/myfile.csv", content);
+# io:Error? resultRecord = io:fileWriteCsv("./resources/myfileRecord.csv", contentRecord);
 # ```
 # + path - The CSV file path
-# + content - CSV content as an array of string arrays, or as an array of map<anydata>
+# + content - CSV content as an array of string arrays or a array of Ballerina records
 # + option - To indicate whether to overwrite or append the given content
 # + return - `()` when the writing was successful or an `io:Error`
 public isolated function fileWriteCsv(string path, string[][]|map<anydata>[] content, FileWriteOption option = OVERWRITE) returns
@@ -58,10 +61,15 @@ Error? {
 }
 
 # Write CSV record stream to a file.
+# If the input is of `stream<record{}, io:Error?>` type, the field names of the record{} are written as headers to the file. Additionally if the CSV contains data records, the header is used to identify the order of the values.
 # ```ballerina
+# type Coord record {int x;int y;};
+# Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]
 # string[][] content = [["Anne", "Johnson", "SE"], ["John", "Cameron", "QA"]];
-# stream<string[], io:Error?> recordStream = content.toStream();
-# io:Error? result = io:fileWriteCsvFromStream("./resources/myfile.csv", recordStream);
+# stream<string[], io:Error?> stringStream = content.toStream();
+# stream<Coord, io:Error?> recordStream = contentRecord.toStream();
+# io:Error? result = io:fileWriteCsvFromStream("./resources/myfile.csv", stringStream);
+# io:Error? resultRecord = io:fileWriteCsvFromStream("./resources/myfileRecord.csv", recordStream);
 # ```
 # + path - The CSV file path
 # + content - A CSV record stream to be written

--- a/ballerina/file_csv_io.bal
+++ b/ballerina/file_csv_io.bal
@@ -43,7 +43,8 @@ public isolated function fileReadCsvAsStream(string path, typedesc<string[]|map<
 } external;
 
 # Write CSV content to a file.
-# If the input is of `record{}[]` type, the field names of the record{} are written as headers to the file. Additionally if the CSV contains data records, the header is used to identify the order of the values.
+# When the input is a record[] type in `OVERWRITE`,  headers will be written to the CSV file by default.
+# For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 # ```ballerina
 # type Coord record {int x;int y;};
 # Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]
@@ -61,7 +62,8 @@ Error? {
 }
 
 # Write CSV record stream to a file.
-# If the input is of `stream<record{}, io:Error?>` type, the field names of the record{} are written as headers to the file. Additionally if the CSV contains data records, the header is used to identify the order of the values.
+# When the input is a `stream<record, io:Error?>` in `OVERWRITE`,  headers will be written to the CSV file by default.
+# For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 # ```ballerina
 # type Coord record {int x;int y;};
 # Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]

--- a/ballerina/tests/csv_io.bal
+++ b/ballerina/tests/csv_io.bal
@@ -382,7 +382,6 @@ function testWritenUnorderedRecordCsv() returns error? {
         }
     }
 }
-
 @test:Config {dependsOn: [testWritenUnorderedRecordCsv]}
 function testCsvAppendWithUnorderedRecords() returns error? {
     record {|
@@ -412,6 +411,81 @@ function testAppededUnorderedRecordCsv() returns error? {
     string[][] result2 = check fileReadCsv(filePath2, 0);
 
     test:assertNotEquals(result[0], result2[0]);
+    string[] headers = result[0];
+
+    foreach int index in 2 ... result.length() - 1 {
+        test:assertEquals(result[index], result[index - 1]);
+        foreach int subIndex in 0 ... 3 {
+            test:assertEquals(result[index][subIndex], content[index - 2].get(headers[subIndex]).toString());
+        }
+    }
+}
+
+@test:Config {}
+function testAppendCsvStreamWithUnorderedRecords() returns error? {
+    record {|
+        int A1;
+        int B1;
+        int B2;
+        int A2;
+    |} d4 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B[] content = [d4];
+    string filePath = TEMP_DIR + "records_unordered_records.csv";
+    test:assertEquals(check fileWriteCsvFromStream(filePath, content.toStream(), APPEND), ());
+}
+
+
+@test:Config {dependsOn: [testAppendCsvStreamWithUnorderedRecords]}
+function testStreamAppededUnorderedRecordCsv() returns error? {
+    string filePath = TEMP_DIR + "records_unordered_records.csv";
+    string filePath2 = TEMP_DIR + "records_unordered_records2.csv";
+    B d1 = {A1: 1, A2: 2, B1: 3, B2: 4};
+    B d2 = {B1: 3, B2: 4, A1: 1, A2: 2};
+    B d3 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B d4 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B d5 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B d6 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B[] content = [d1, d2, d3, d4, d5, d6];
+    string[][] result = check fileReadCsv(filePath, 0);
+    string[][] result2 = check fileReadCsv(filePath2, 0);
+
+    test:assertNotEquals(result[0], result2[0]);
+    string[] headers = result[0];
+
+    foreach int index in 2 ... result.length() - 1 {
+        test:assertEquals(result[index], result[index - 1]);
+        foreach int subIndex in 0 ... 3 {
+            test:assertEquals(result[index][subIndex], content[index - 2].get(headers[subIndex]).toString());
+        }
+    }
+}
+
+@test:Config {}
+function testCsvStreamWriteWithUnorderedRecords() returns error? {
+    B d1 = {A1: 1, A2: 2, B1: 3, B2: 4};
+    C d2 = {B1: 3, B2: 4, A1: 1, A2: 2};
+    C d3 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    record {|
+        int A1;
+        int B1;
+        int B2;
+        int A2;
+    |} d4 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B[] content = [d1, d2, d3, d4];
+    string filePath = TEMP_DIR + "records_unordered_records_stream.csv";
+    test:assertEquals(check fileWriteCsv(filePath, content), ());
+}
+
+@test:Config {dependsOn: [testCsvStreamWriteWithUnorderedRecords]}
+function testWritenUnorderedRecordCsvStream() returns error? {
+    string filePath = TEMP_DIR + "records_unordered_records_stream.csv";
+    B d1 = {A1: 1, A2: 2, B1: 3, B2: 4};
+    B d2 = {B1: 3, B2: 4, A1: 1, A2: 2};
+    B d3 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B d4 = {A1: 1, B1: 3, B2: 4, A2: 2};
+    B[] content = [d1, d2, d3, d4];
+    string[][] result = check fileReadCsv(filePath, 0);
+
     string[] headers = result[0];
 
     foreach int index in 2 ... result.length() - 1 {
@@ -468,28 +542,103 @@ isolated function testWriteCsvAsRecordStream() returns Error? {
 
 @test:Config {dependsOn: [testWriteCsvAsRecordStream]}
 function testWritenCsvAsRecordStreamRead() returns error? {
-    Employee E = {
+    EmployeeStringSalary A = {
+        id: "id",
+        name: "name",
+        salary: "salary"
+    };
+    EmployeeStringSalary E = {
         id: "1",
         name: "Foo1",
-        salary: 100000.0f
+        salary: "100000.0"
     };
-    Employee B = {
+    EmployeeStringSalary B = {
         id: "2",
         name: "Foo2",
-        salary: 300000.0f
+        salary: "300000.0"
     };
-    Employee[] expected = [E, B];
+    EmployeeStringSalary[] expected = [A, E, B];
     string filePath = TEMP_DIR + "recordsDefault_stream.csv";
-    stream<Employee, Error?> result = check fileReadCsvAsStream(filePath);
+    stream<EmployeeStringSalary, Error?> result = check fileReadCsvAsStream(filePath);
     int i = 0;
-    check result.forEach(function(Employee val) {
+    check result.forEach(function(EmployeeStringSalary val) {
         test:assertEquals(val.salary, expected[i].salary);
         test:assertEquals(val.id, expected[i].id);
         test:assertEquals(val.name, expected[i].name);
         i = i + 1;
     });
-    test:assertEquals(i, 2);
+    test:assertEquals(i, 3);
 }
+
+
+@test:Config {dependsOn: [testWritenCsvAsRecordStreamRead]}
+isolated function testAppendCsvAsRecordStream() returns Error? {
+    Employee A = {
+        id: "3",
+        name: "Foo1",
+        salary: 100000.0f
+    };
+    Employee B = {
+        id: "4",
+        name: "Foo2",
+        salary: 300000.0f
+    };
+        Employee C = {
+        name: "Foo2",
+        id: "5",
+        salary: 300000.0f
+    };
+
+    string filePath = TEMP_DIR + "recordsDefault_stream.csv";
+    Employee[] content1 = [A, B, C];
+    test:assertEquals(check fileWriteCsvFromStream(filePath, content1.toStream(), APPEND), ());
+}
+
+@test:Config {dependsOn: [testAppendCsvAsRecordStream]}
+function testAppendedCsvAsRecordStreamRead() returns error? {
+    EmployeeStringSalary A = {
+        id: "1",
+        name: "Foo1",
+        salary: "100000.0"
+    };
+    EmployeeStringSalary B = {
+        id: "2",
+        name: "Foo2",
+        salary: "300000.0"
+    };
+    EmployeeStringSalary C = {
+        id: "3",
+        name: "Foo1",
+        salary: "100000.0"
+    };
+    EmployeeStringSalary D = {
+        id: "4",
+        name: "Foo2",
+        salary: "300000.0"
+    };
+        EmployeeStringSalary E = {
+        name: "Foo2",
+        id: "5",
+        salary: "300000.0"
+    };
+    EmployeeStringSalary[] expected = [A, B, C, D, E];
+    string filePath = TEMP_DIR + "recordsDefault_stream.csv";
+    stream<EmployeeStringSalary, Error?> result = check fileReadCsvAsStream(filePath);
+    int i = 0;
+    check result.forEach(function(EmployeeStringSalary val) {
+        if i == 0 {
+            i +=1;
+        } else {
+            test:assertEquals(val.salary, expected[i-1].salary);
+            test:assertEquals(val.id, expected[i-1].id);
+            test:assertEquals(val.name, expected[i-1].name);
+        i = i + 1;
+        }
+    });
+    test:assertEquals(i, 6);
+}
+
+
 
 @test:Config {}
 isolated function testOpenAndReadCsv() returns Error? {
@@ -1114,6 +1263,7 @@ function testFileReadCsvAsStreamUsingResourceFile() returns error? {
 function testFileReadCsvAsStreamUsingResourceFileRecords() returns error? {
     string filePath = TEMP_DIR + "workers4_A.csv";
     string[][] expectedContent = [
+        ["name", "designation", "company","age", "residence"],
         ["Anne Hamiltom", "Software Engineer", "Microsoft", "26 years", "New York"],
         [
             "John Thomson",
@@ -1140,7 +1290,7 @@ function testFileReadCsvAsStreamUsingResourceFileRecords() returns error? {
         }
         i += 1;
     });
-    test:assertEquals(i, 3);
+    test:assertEquals(i, 4);
 }
 
 @test:Config {}

--- a/ballerina/tests/csv_io.bal
+++ b/ballerina/tests/csv_io.bal
@@ -300,7 +300,7 @@ function testWritenRecordCsv() returns error? {
     test:assertEquals(i, 3);
 }
 
-@test:Config {dependsOn: [writeEmptyStringArraytoCsv]}
+@test:Config {dependsOn: [writeEmptyStreamtoCsv]}
 isolated function testAppendRecordCsvToEmptyFile() returns Error? {
     EmployeeStringSalary E = {
         id: "1",
@@ -312,7 +312,7 @@ isolated function testAppendRecordCsvToEmptyFile() returns Error? {
         name: "Foo2",
         salary: "300000.0"
     };
-    string filePath = TEMP_DIR + "empty3.csv";
+    string filePath = TEMP_DIR + "empty.csv";
     EmployeeStringSalary[] content1 = [E, B];
     test:assertEquals(check fileWriteCsv(filePath, content1, APPEND), ());
 }
@@ -335,7 +335,7 @@ function testAppendedRecordCsvToEmptyFile() returns error? {
         salary: "300000.0"
     };
     EmployeeStringSalary[] expected = [H, E, B];
-    string filePath = TEMP_DIR + "empty3.csv";
+    string filePath = TEMP_DIR + "empty.csv";
     stream<EmployeeStringSalary, Error?> result = check fileReadCsvAsStream(filePath);
     int i = 0;
     check result.forEach(function(EmployeeStringSalary val) {

--- a/ballerina/tests/csv_io.bal
+++ b/ballerina/tests/csv_io.bal
@@ -435,7 +435,7 @@ function testAppendCsvStreamWithUnorderedRecords() returns error? {
 }
 
 
-@test:Config {dependsOn: [testAppendCsvStreamWithUnorderedRecords]}
+@test:Config {dependsOn: [testAppendCsvStreamWithUnorderedRecords, testWritenUnorderedRecordCsv]}
 function testStreamAppededUnorderedRecordCsv() returns error? {
     string filePath = TEMP_DIR + "records_unordered_records.csv";
     string filePath2 = TEMP_DIR + "records_unordered_records2.csv";

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ This file contains all the notable changes done to the Ballerina I/O package thr
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] 
-### Fixed
+### Changed
 - [Fixed the issue related to maintaining order in writing CSV records](https://github.com/ballerina-platform/ballerina-standard-library/issues/3399)
 
 ## [1.3.1] - 2022-11-29

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,11 @@ This file contains all the notable changes done to the Ballerina I/O package thr
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [Unreleased]
+## [Unreleased] 
+### Fixed
+- [Fixed the issue related to maintaining order in writing CSV records](https://github.com/ballerina-platform/ballerina-standard-library/issues/3399)
+
+## [1.3.1] - 2022-11-29
 ### Changed
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -331,7 +331,7 @@ The following API writes a given CSV stream to a given file. When writing a `Rec
 
 ```ballerina
 # Write CSV record stream to a file. 
-# When the input is a record[] type stream in `OVERWRITE`,  headers will be written to the CSV file by default.
+# When the input is a `stream<record, io:Error?>` in `OVERWRITE`,  headers will be written to the CSV file by default.
 # For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 # ```ballerina
 # type Coord record {int x;int y;};

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -279,21 +279,21 @@ public isolated function fileWriteLinesFromStream(string path, stream<string, Er
 
 **Non-Streaming APIs**
 
-The following API reads the content of a given CSV file as a string array of arrays. Here, each CSV record represents as a string array.
+The following API reads the content of a given CSV file as a string array of arrays or array of ballerina records. Here, each CSV record represents as a string array or a record.
 
 ```ballerina
 # Read file content as a CSV.
 # ```ballerina
 # string[][]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
-# map<anydata>[]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
+# record[]|io:Error content = io:fileReadCsv("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
-# + return - The entire CSV content in the channel as an array of string arrays or an `io:Error`
+# + return - The entire CSV content in the channel as an array of string arrays, array of ballerina records or an `io:Error`
 public isolated function fileReadCsv(string path, int skipHeaders = 0) returns string[][]|Error;
 ```
 
-The following API writes given CSV content to a given file. When writing a `Record[]` content to a CSV file in `OVERWRITE`, by default, headers will be written to the CSV file as unlike `string[][],` the order of record fields is not guaranteed. For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
+The following API writes given CSV content to a given file. When writing a `Record[]` content to a CSV file in `OVERWRITE`, by default, headers will be written to the CSV file as unlike `string[][],` the order of ballerina record fields is not guaranteed. For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 
 ```ballerina
 # Write CSV content to a file. 
@@ -306,27 +306,27 @@ The following API writes given CSV content to a given file. When writing a `Reco
 # io:Error? resultRecord = io:fileWriteCsv("./resources/myfileRecord.csv", contentRecord);
 # ```
 # + path - The CSV file path
-# + content - CSV content as an array of string arrays
+# + content - CSV content as an array of string arrays or a array of ballerina records.
 # + option - To indicate whether to overwrite or append the given content
 # + return - An `io:Error` or `()` when the writing was successful
 public isolated function fileWriteCsv(string path, string[][] content, FileWriteOption option = OVERWRITE) returns
 Error?;
 ```
 
-The following API reads the content of a given CSV file as a stream of string arrays. Here, each CSV record represents as a string array.
+The following API reads the content of a given CSV file as a stream of string arrays or ballerina records. Here, each CSV record represents as a string array or a ballerina record.
 
 ```ballerina
 # Read file content as a CSV.
 # ```ballerina
 # stream<string[], io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
-# stream<map<anydata>, io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
+# stream<record{}, io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
-# + return - The entire CSV content in the channel a stream of string arrays or an `io:Error`
+# + return - The entire CSV content in the channel a stream of string arrays, ballerina records or an `io:Error`
 public isolated function fileReadCsvAsStream(string path) returns stream<string[], Error?>|Error;
 ```
 
-The following API writes a given CSV stream to a given file.
+The following API writes a given CSV stream to a given file. When writing a `Record[]` content to a CSV file in `OVERWRITE`, by default, headers will be written to the CSV file as unlike `string[]` the order of record fields is not guaranteed. For `APPEND`, order of the existing csv file is inferred using the headers and used as the order
 
 ```ballerina
 # Write CSV record stream to a file.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -289,7 +289,7 @@ The following API reads the content of a given CSV file as a string array of arr
 # ```
 # + path - The CSV file path
 # + skipHeaders - Number of headers, which should be skipped prior to reading records
-# + return - The entire CSV content in the channel as an array of string arrays, array of ballerina records or an `io:Error`
+# + return - The entire CSV content in the channel as an array of string arrays, array of Ballerina records or an `io:Error`
 public isolated function fileReadCsv(string path, int skipHeaders = 0) returns string[][]|Error;
 ```
 
@@ -306,7 +306,7 @@ The following API writes given CSV content to a given file. When writing a `Reco
 # io:Error? resultRecord = io:fileWriteCsv("./resources/myfileRecord.csv", contentRecord);
 # ```
 # + path - The CSV file path
-# + content - CSV content as an array of string arrays or a array of ballerina records.
+# + content - CSV content as an array of string arrays or a array of Ballerina records.
 # + option - To indicate whether to overwrite or append the given content
 # + return - An `io:Error` or `()` when the writing was successful
 public isolated function fileWriteCsv(string path, string[][] content, FileWriteOption option = OVERWRITE) returns
@@ -322,7 +322,7 @@ The following API reads the content of a given CSV file as a stream of string ar
 # stream<record{}, io:Error?>|io:Error content = io:fileReadCsvAsStream("./resources/myfile.csv");
 # ```
 # + path - The CSV file path
-# + return - The entire CSV content in the channel a stream of string arrays, ballerina records or an `io:Error`
+# + return - The entire CSV content in the channel a stream of string arrays, Ballerina records or an `io:Error`
 public isolated function fileReadCsvAsStream(string path) returns stream<string[], Error?>|Error;
 ```
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -297,7 +297,8 @@ The following API writes given CSV content to a given file. When writing a `Reco
 
 ```ballerina
 # Write CSV content to a file. 
-# If the input is a `Record[]` the headers are automatically written to the file.
+# When the input is a record[] type in `OVERWRITE`,  headers will be written to the CSV file by default.
+# For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 # ```ballerina
 # type Coord record {int x;int y;};
 # Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]
@@ -329,7 +330,9 @@ public isolated function fileReadCsvAsStream(string path) returns stream<string[
 The following API writes a given CSV stream to a given file. When writing a `Record[]` content to a CSV file in `OVERWRITE`, by default, headers will be written to the CSV file as unlike `string[]` the order of record fields is not guaranteed. For `APPEND`, order of the existing csv file is inferred using the headers and used as the order
 
 ```ballerina
-# Write CSV record stream to a file.
+# Write CSV record stream to a file. 
+# When the input is a record[] type stream in `OVERWRITE`,  headers will be written to the CSV file by default.
+# For `APPEND`, order of the existing csv file is inferred using the headers and used as the order.
 # ```ballerina
 # type Coord record {int x;int y;};
 # Coord[] contentRecord = [{x: 1,y: 2},{x: 1,y: 2}]


### PR DESCRIPTION
## Purpose
This will fix the issue related to maintaining field order in `fileWriteCsvFromStream()` API
Fixes: [3399](https://github.com/ballerina-platform/ballerina-standard-library/issues/3399)
## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
