### PR TITLE
Change `testReadInvalidXmlFile` test

### DIFF
--- a/ballerina/tests/xml_io.bal
+++ b/ballerina/tests/xml_io.bal
@@ -334,6 +334,9 @@ isolated function testReadInvalidXmlFile() returns Error? {
 
     xml|Error readResult = fileReadXml(filePath);
     test:assertTrue(readResult is Error);
-    test:assertTrue(langstring:includes((<Error>readResult).message(),
-        "failed to create xml: Unexpected character '{' (code 123) in prolog; expected '<", 0));
+    string readResultMessage = (<Error>readResult).message();
+    test:assertTrue(langstring:includes(readResultMessage,
+    "failed to create xml: Unexpected character '{' (code 123) in prolog; expected '<", 0)
+    || langstring:includes(readResultMessage,
+    "failed to parse xml: Unexpected character '{' (code 123) in prolog; expected '<", 0));
 }


### PR DESCRIPTION
## Purpose

To comply with the change done for the xml parser to throw an error with the same message prefix  https://github.com/ballerina-platform/ballerina-lang/pull/40286#discussion_r1187280634.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
