### PR TITLE
Update the order of test execution

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.7.0-20230619-175900-bb4e4544"
+distribution-version = "2201.7.0-20230622-064700-4a2dc6dd"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/tests/string_io.bal
+++ b/ballerina/tests/string_io.bal
@@ -465,7 +465,7 @@ function testFileWriteLinesFromStreamWithAppend() returns Error? {
     test:assertEquals(i, 9);
 }
 
-@test:Config {}
+@test:Config {dependsOn: [testFileWriteStringWithAppend]}
 isolated function testFileChannelWriteStringWithByteChannel() returns Error? {
     string filePath = TEMP_DIR + "stringContent3.txt";
     string content = "The Big Bang Theory";
@@ -484,7 +484,7 @@ isolated function testFileChannelReadStringWithByteChannel() returns Error? {
     test:assertEquals(result, expectedString);
 }
 
-@test:Config {}
+@test:Config {dependsOn: [testFileChannelReadStringWithByteChannel]}
 isolated function testFileChannelWriteLinesWithByteChannel() returns Error? {
     string filePath = TEMP_DIR + "stringContent3.txt";
     string content = "The Big Bang Theory";


### PR DESCRIPTION
## Purpose
Currently `stringContent3.txt` file is used in multiple places without defining the order of execution properly. This PR will fix the issue.
## Examples

## Checklist
- [ ]~ Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
