### PR TITLE
Fix the test case to read characters from a file

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 authors = ["Ballerina"]
 keywords = ["io", "json", "xml", "csv", "file"]
 repository = "https://github.com/ballerina-platform/module-ballerina-io"
@@ -15,16 +15,16 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "io-native"
-path = "../native/build/libs/io-native-1.8.0.jar"
-version = "1.8.0"
+path = "../native/build/libs/io-native-1.8.1-SNAPSHOT.jar"
+version = "1.8.1"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "io-compiler-plugin"
-version = "1.8.0"
-path = "../compiler-plugin/build/libs/io-compiler-plugin-1.8.0.jar"
+version = "1.8.1"
+path = "../compiler-plugin/build/libs/io-compiler-plugin-1.8.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
-path = "../test-utils/build/libs/io-test-utils-1.8.0.jar"
+path = "../test-utils/build/libs/io-test-utils-1.8.1-SNAPSHOT.jar"
 scope = "testOnly"
-version = "1.8.0"
+version = "1.8.1-SNAPSHOT"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "io-compiler-plugin"
 class = "io.ballerina.stdlib.io.compiler.IOCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/io-compiler-plugin-1.8.0.jar"
+path = "../compiler-plugin/build/libs/io-compiler-plugin-1.8.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.float"},

--- a/ballerina/tests/string_io.bal
+++ b/ballerina/tests/string_io.bal
@@ -42,8 +42,7 @@ isolated function testReadCharacters() returns Error? {
 isolated function testReadAllCharacters() returns Error? {
     string filePath = RESOURCES_BASE_PATH + "datafiles/io/text/fileThatExceeds2MB.txt";
     string result = "";
-    int expectedNumberOfCharsInWindows = 2297329;
-    int expectedNumberOfCharsInLinux = 2265223;
+    int expectedNumberOfChars = 2265223;
     int fixedSize = 500;
     boolean isDone = false;
 
@@ -62,12 +61,7 @@ isolated function testReadAllCharacters() returns Error? {
             }
         }
     }
-    if isWindowsEnvironment() {
-        test:assertEquals(result.length(), expectedNumberOfCharsInWindows);
-    } else {
-        test:assertEquals(result.length(), expectedNumberOfCharsInLinux);
-    }
-
+    test:assertEquals(result.length(), expectedNumberOfChars);
     check characterChannel.close();
 }
 


### PR DESCRIPTION
## Purpose
As per [PR #7946](https://github.com/ballerina-platform/ballerina-library/pull/7946), the workflow files have been updated to prevent automatically converting LF to CRLF on Windows systems. As a result, the character count remains the same across both operating systems.
