### PR TITLE
Fix resource leak in CSV stream/record channel on I/O error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,14 @@ This file contains all the notable changes done to the Ballerina I/O package thr
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Fixed
+- [Fix resource leak in CSV stream/record channel on I/O error](https://github.com/ballerina-platform/ballerina-library/issues/8804)
+
+## [1.8.0] - 2025-03-12
 ### Added
 - [Add static code rules](https://github.com/ballerina-platform/ballerina-library/issues/7283)
 
+## [1.7.0] - 2025-02-07
 ### Fixed
 - [The CSV file read as a record failed when a nillable field was empty](https://github.com/ballerina-platform/ballerina-library/issues/7433)
 

--- a/native/src/main/java/io/ballerina/stdlib/io/nativeimpl/RecordChannelUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/io/nativeimpl/RecordChannelUtils.java
@@ -229,6 +229,10 @@ public class RecordChannelUtils {
             String[] records = textRecordChannel.getFields(line);
             return StringUtils.fromStringArray(records);
         } catch (IOException e) {
+            try {
+                bufferedReader.close();
+            } catch (IOException ignored) {
+            }
             return IOUtils.createError(e);
         }
     }
@@ -246,6 +250,10 @@ public class RecordChannelUtils {
             String[] record = textRecordChannel.getFields(line);
             return StringUtils.fromStringArray(record);
         } catch (IOException e) {
+            try {
+                bufferedReader.close();
+            } catch (IOException ignored) {
+            }
             return IOUtils.createError(e);
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/io/nativeimpl/RecordChannelUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/io/nativeimpl/RecordChannelUtils.java
@@ -232,6 +232,7 @@ public class RecordChannelUtils {
             try {
                 bufferedReader.close();
             } catch (IOException ignored) {
+                // Close failure is ignored; the original I/O error is returned to the caller
             }
             return IOUtils.createError(e);
         }
@@ -253,6 +254,7 @@ public class RecordChannelUtils {
             try {
                 bufferedReader.close();
             } catch (IOException ignored) {
+                // Close failure is ignored; the original I/O error is returned to the caller
             }
             return IOUtils.createError(e);
         }


### PR DESCRIPTION
## Summary

Fixes: ballerina-platform/ballerina-library#8804

- Fix `BufferedReader` resource leak in `RecordChannelUtils`: the `catch (IOException e)` blocks in both `streamNext()` and `readRecord()` now close the reader before returning the error, preventing a leak when an I/O error occurs mid-read (related: ballerina-platform/ballerina-library#8804)
- Fix `testReadAllCharacters` test to handle different character counts on Windows vs Linux environments
- Update `changelog.md` to correctly attribute past fixes to their released versions (`[1.7.0]` and `[1.8.0]`) and add entry for this fix under `[Unreleased]`

## Test plan

- [ ] Existing CSV read/stream tests cover the normal and EOF paths
- [ ] The IOException error path cannot be triggered from the Ballerina test layer; the fix is verified by code inspection
- [ ] Run `./gradlew clean build` to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves resource management in the CSV stream and record channel handling by ensuring proper cleanup of resources when I/O errors occur. 

### Changes Made

**RecordChannelUtils.java:**
- Enhanced the `streamNext()` and `readRecord()` methods to properly close the associated `BufferedReader` in their error handling blocks before returning errors, preventing resource leaks during I/O failures.

**changelog.md:**
- Updated to reflect the fix for the resource leak in the CSV stream/record channel.
- Corrected attribution of previously fixed issues to their respective released versions.

### Testing

The fix is validated through:
- Existing test coverage for normal and end-of-file scenarios
- Code inspection for the I/O error path (which cannot be directly triggered from Ballerina tests)
- Build verification via Gradle

A test adjustment was made to `testReadAllCharacters` to accommodate platform-specific character count variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerina-io/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->